### PR TITLE
Add working-directory input

### DIFF
--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: somewhere
-    - uses: ./
+    - uses: ./somewhere
       id: filter
       with:
         token: ''

--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -54,3 +54,19 @@ jobs:
     - name: filter-test
       if: steps.filter.outputs.any != 'true' || steps.filter.outputs.error == 'true'
       run: exit 1
+
+  test-wd-without-token:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: somewhere
+    - uses: ./
+      id: filter
+      with:
+        token: ''
+        working-directory: somewhere
+        filters: '.github/filters.yml'
+    - name: filter-test
+      if: steps.filter.outputs.any != 'true' || steps.filter.outputs.error == 'true'
+      run: exit 1

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Output variables can be later used in the `if` clause to conditionally run speci
 
 ### Inputs
 - **`token`**: GitHub Access Token - defaults to `${{ github.token }}` so you don't have to explicitly provide it.
+- **`working-directory`: Relative path under $GITHUB_WORKSPACE where the repository was checked out. Useful only if you checked out your repository under custom path.
 - **`base`**: Git reference (e.g. branch name) against which the changes will be detected. Defaults to repository default branch (e.g. master).
               If it references same branch it was pushed to, changes are detected against the most recent commit before the push.
               This option is ignored if action is triggered by *pull_request* event.

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: 'GitHub Access Token'
     required: false
     default: ${{ github.token }}
+  working-directory:
+    description: 'Relative path under $GITHUB_WORKSPACE where the repository was checked out.'
+    required: false
   base:
     description: |
       Git reference (e.g. branch name) against which the changes will be detected. Defaults to repository default branch (e.g. master).

--- a/dist/index.js
+++ b/dist/index.js
@@ -4500,6 +4500,10 @@ const git = __importStar(__webpack_require__(136));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
+            const workingDirectory = core.getInput('working-directory', { required: false });
+            if (workingDirectory) {
+                process.chdir(workingDirectory);
+            }
             const token = core.getInput('token', { required: false });
             const filtersInput = core.getInput('filters', { required: true });
             const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,11 @@ import * as git from './git'
 
 async function run(): Promise<void> {
   try {
+    const workingDirectory = core.getInput('working-directory', {required: false})
+    if (workingDirectory) {
+      process.chdir(workingDirectory)
+    }
+
     const token = core.getInput('token', {required: false})
     const filtersInput = core.getInput('filters', {required: true})
     const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput


### PR DESCRIPTION
If repository is checked out into subfolder of $GITHUB_WORKSPACE, our change detection via git diff-index will fail. Checkout to subfolder is not common scenario but there are valid use cases for that. One example is checkout out multiple repositories.

This PR adds `working-directory` input option.
If this input is set, action will as the first thing change the working directory.
Reading of filters yaml and all git commands are then executed within configured directory.

resolves #18 