### PR TITLE
Export files matching rules

### DIFF
--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -90,6 +90,12 @@ jobs:
             - modified: "LICENSE"
           any:
             - added|deleted|modified: "*"
+    - name: Print 'added_files'
+      run: echo ${{steps.filter.outputs.added_files}}
+    - name: Print 'modified_files'
+      run: echo ${{steps.filter.outputs.modified_files}}
+    - name: Print 'rm_files'
+      run: echo ${{steps.filter.outputs.rm_files}}
     - name: filter-test
       if: |
         steps.filter.outputs.add != 'true'

--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -97,12 +97,15 @@ jobs:
     - name: Print 'deleted_files'
       run: echo ${{steps.filter.outputs.deleted_files}}
     - name: filter-test
+      # only single quotes are supported in GH action literal
+      # single quote needs to be escaped with single quote
+      # '''add.txt''' resolves to string 'add.txt'
       if: |
         steps.filter.outputs.added != 'true'
         || steps.filter.outputs.deleted != 'true'
         || steps.filter.outputs.modified != 'true'
         || steps.filter.outputs.any != 'true'
-        || steps.filter.outputs.added_files != "'add.txt'"
-        || steps.filter.outputs.modified_files != "'LICENSE'"
-        || steps.filter.outputs.deleted_files != "'README.md'"
+        || steps.filter.outputs.added_files != '''add.txt'''
+        || steps.filter.outputs.modified_files != '''LICENSE'''
+        || steps.filter.outputs.deleted_files != '''README.md'''
       run: exit 1

--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -102,7 +102,7 @@ jobs:
         || steps.filter.outputs.deleted != 'true'
         || steps.filter.outputs.modified != 'true'
         || steps.filter.outputs.any != 'true'
-        || steps.filter.outputs.added_files != 'add.txt'
-        || steps.filter.outputs.modified_files != 'LICENSE'
-        || steps.filter.outputs.deleted_files != 'README.md'
+        || steps.filter.outputs.added_files != "'add.txt'"
+        || steps.filter.outputs.modified_files != "'LICENSE'"
+        || steps.filter.outputs.deleted_files != "'README.md'"
       run: exit 1

--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -80,6 +80,7 @@ jobs:
       id: filter
       with:
         token: ''
+        list-files: shell
         filters: |
           add:
             - added: "add.txt"
@@ -89,15 +90,13 @@ jobs:
             - modified: "LICENSE"
           any:
             - added|deleted|modified: "*"
-    - name: Print changed files
-      run: echo '${{steps.filter.outputs.files}}' | jq .
     - name: filter-test
       if: |
         steps.filter.outputs.add != 'true'
         || steps.filter.outputs.rm != 'true'
         || steps.filter.outputs.modified != 'true'
         || steps.filter.outputs.any != 'true'
-        || !contains(fromJSON(steps.filter.outputs.files).added,'add.txt')
-        || !contains(fromJSON(steps.filter.outputs.files).modified,'LICENSE')
-        || !contains(fromJSON(steps.filter.outputs.files).deleted,'README.md')
+        || steps.filter.outputs.added_files != 'add.txt'
+        || steps.filter.outputs.modified_files != 'LICENSE'
+        || steps.filter.outputs.rm_files != 'README.md'
       run: exit 1

--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -82,9 +82,9 @@ jobs:
         token: ''
         list-files: shell
         filters: |
-          add:
+          added:
             - added: "add.txt"
-          rm:
+          deleted:
             - deleted: "README.md"
           modified:
             - modified: "LICENSE"
@@ -94,15 +94,15 @@ jobs:
       run: echo ${{steps.filter.outputs.added_files}}
     - name: Print 'modified_files'
       run: echo ${{steps.filter.outputs.modified_files}}
-    - name: Print 'rm_files'
-      run: echo ${{steps.filter.outputs.rm_files}}
+    - name: Print 'deleted_files'
+      run: echo ${{steps.filter.outputs.deleted_files}}
     - name: filter-test
       if: |
-        steps.filter.outputs.add != 'true'
-        || steps.filter.outputs.rm != 'true'
+        steps.filter.outputs.added != 'true'
+        || steps.filter.outputs.deleted != 'true'
         || steps.filter.outputs.modified != 'true'
         || steps.filter.outputs.any != 'true'
         || steps.filter.outputs.added_files != 'add.txt'
         || steps.filter.outputs.modified_files != 'LICENSE'
-        || steps.filter.outputs.rm_files != 'README.md'
+        || steps.filter.outputs.deleted_files != 'README.md'
       run: exit 1

--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -1,4 +1,4 @@
-import Filter from '../src/filter'
+import {Filter} from '../src/filter'
 import {File, ChangeStatus} from '../src/file'
 
 describe('yaml filter parsing tests', () => {
@@ -25,8 +25,9 @@ describe('matching tests', () => {
     src: "src/**/*.js"
     `
     let filter = new Filter(yaml)
-    const match = filter.match(modified(['src/app/module/file.js']))
-    expect(match.src).toBeTruthy()
+    const files = modified(['src/app/module/file.js'])
+    const match = filter.match(files)
+    expect(match.src).toEqual(files)
   })
   test('matches single rule in single group', () => {
     const yaml = `
@@ -34,8 +35,9 @@ describe('matching tests', () => {
       - src/**/*.js
     `
     const filter = new Filter(yaml)
-    const match = filter.match(modified(['src/app/module/file.js']))
-    expect(match.src).toBeTruthy()
+    const files = modified(['src/app/module/file.js'])
+    const match = filter.match(files)
+    expect(match.src).toEqual(files)
   })
 
   test('no match when file is in different folder', () => {
@@ -45,7 +47,7 @@ describe('matching tests', () => {
     `
     const filter = new Filter(yaml)
     const match = filter.match(modified(['not_src/other_file.js']))
-    expect(match.src).toBeFalsy()
+    expect(match.src).toEqual([])
   })
 
   test('match only within second groups ', () => {
@@ -56,9 +58,10 @@ describe('matching tests', () => {
       - test/**/*.js
     `
     const filter = new Filter(yaml)
-    const match = filter.match(modified(['test/test.js']))
-    expect(match.src).toBeFalsy()
-    expect(match.test).toBeTruthy()
+    const files = modified(['test/test.js'])
+    const match = filter.match(files)
+    expect(match.src).toEqual([])
+    expect(match.test).toEqual(files)
   })
 
   test('match only withing second rule of single group', () => {
@@ -68,18 +71,20 @@ describe('matching tests', () => {
       - test/**/*.js
     `
     const filter = new Filter(yaml)
-    const match = filter.match(modified(['test/test.js']))
-    expect(match.src).toBeTruthy()
+    const files = modified(['test/test.js'])
+    const match = filter.match(files)
+    expect(match.src).toEqual(files)
   })
 
   test('matches anything', () => {
     const yaml = `
     any:
-      - "**/*"
+      - "**"
     `
     const filter = new Filter(yaml)
-    const match = filter.match(modified(['test/test.js']))
-    expect(match.any).toBeTruthy()
+    const files = modified(['test/test.js'])
+    const match = filter.match(files)
+    expect(match.any).toEqual(files)
   })
 
   test('globbing matches path where file or folder name starts with dot', () => {
@@ -88,8 +93,9 @@ describe('matching tests', () => {
       - "**/*.js"
     `
     const filter = new Filter(yaml)
-    const match = filter.match(modified(['.test/.test.js']))
-    expect(match.dot).toBeTruthy()
+    const files = modified(['.test/.test.js'])
+    const match = filter.match(files)
+    expect(match.dot).toEqual(files)
   })
 
   test('matches path based on rules included using YAML anchor', () => {
@@ -101,9 +107,10 @@ describe('matching tests', () => {
       - *shared
       - src/**/*
     `
-    let filter = new Filter(yaml)
-    const match = filter.match(modified(['config/settings.yml']))
-    expect(match.src).toBeTruthy()
+    const filter = new Filter(yaml)
+    const files = modified(['config/settings.yml'])
+    const match = filter.match(files)
+    expect(match.src).toEqual(files)
   })
 })
 
@@ -115,7 +122,7 @@ describe('matching specific change status', () => {
     `
     let filter = new Filter(yaml)
     const match = filter.match(modified(['file.js']))
-    expect(match.add).toBeFalsy()
+    expect(match.add).toEqual([])
   })
 
   test('match added file as added', () => {
@@ -124,17 +131,20 @@ describe('matching specific change status', () => {
       - added: "**/*"
     `
     let filter = new Filter(yaml)
-    const match = filter.match([{status: ChangeStatus.Added, filename: 'file.js'}])
-    expect(match.add).toBeTruthy()
+    const files = [{status: ChangeStatus.Added, filename: 'file.js'}]
+    const match = filter.match(files)
+    expect(match.add).toEqual(files)
   })
+
   test('matches when multiple statuses are configured', () => {
     const yaml = `
     addOrModify:
       - added|modified: "**/*"
     `
     let filter = new Filter(yaml)
-    const match = filter.match([{status: ChangeStatus.Modified, filename: 'file.js'}])
-    expect(match.addOrModify).toBeTruthy()
+    const files = [{status: ChangeStatus.Modified, filename: 'file.js'}]
+    const match = filter.match(files)
+    expect(match.addOrModify).toEqual(files)
   })
 })
 

--- a/__tests__/shell-escape.test.ts
+++ b/__tests__/shell-escape.test.ts
@@ -1,7 +1,7 @@
 import shellEscape from '../src/shell-escape'
 
-test('simple path is not escaped', () => {
-  expect(shellEscape('file')).toBe('file')
+test('simple path escaped', () => {
+  expect(shellEscape('file')).toBe("'file'")
 })
 
 test('path with space is wrapped with single quotes', () => {
@@ -10,4 +10,7 @@ test('path with space is wrapped with single quotes', () => {
 
 test('path with quote is divided into quoted segments and escaped quote', () => {
   expect(shellEscape("file'with quote")).toBe("'file'\\''with quote'")
+})
+test('path with leading quote does not have double quotes at beginning', () => {
+  expect(shellEscape("'file-leading-quote")).toBe("\\''file-leading-quote'")
 })

--- a/__tests__/shell-escape.test.ts
+++ b/__tests__/shell-escape.test.ts
@@ -1,0 +1,13 @@
+import shellEscape from '../src/shell-escape'
+
+test('simple path is not escaped', () => {
+  expect(shellEscape('file')).toBe('file')
+})
+
+test('path with space is wrapped with single quotes', () => {
+  expect(shellEscape('file with space')).toBe("'file with space'")
+})
+
+test('path with quote is divided into quoted segments and escaped quote', () => {
+  expect(shellEscape("file'with quote")).toBe("'file'\\''with quote'")
+})

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,12 @@ inputs:
   filters:
     description: 'Path to the configuration file or YAML string with filters definition'
     required: false
-  format:
-    description: 'Output format of listed matching files: none | json | shell'
+  list-files:
+    description: |
+      Enables listing of files matching the filter:
+        'none'  - Disables listing of matching files (default).
+        'json'  - Matching files paths are serialized as JSON array.
+        'shell' - Matching files paths are escaped and space-delimited. Output is usable as command line argument list in linux shell.
     required: false
     default: none
 runs:

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,10 @@ inputs:
   filters:
     description: 'Path to the configuration file or YAML string with filters definition'
     required: false
-outputs:
-  files:
-    description: 'Changed files grouped by status - added, deleted or modified.'
+  format:
+    description: 'Output format of listed matching files: none | json | shell'
+    required: false
+    default: none
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -4675,8 +4675,9 @@ function exportResults(results, format) {
     for (const [key, files] of Object.entries(results)) {
         const value = files.length > 0;
         core.startGroup(`Filter ${key} = ${value}`);
+        core.info('Matching files:');
         for (const file of files) {
-            core.info(`Matched file: ${file.filename} [${file.status}]`);
+            core.info(`${file.filename} [${file.status}]`);
         }
         core.setOutput(key, value);
         if (format !== 'none') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -15299,15 +15299,10 @@ module.exports = require("fs");
 
 // Credits to https://github.com/xxorax/node-shell-escape
 Object.defineProperty(exports, "__esModule", { value: true });
-const needEscape = /[^A-Za-z0-9_/:=-]/;
 function shellEscape(value) {
-    if (needEscape.test(value)) {
-        value = `'${value.replace(/'/g, "'\\''")}'`;
-        value = value
-            .replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
-            .replace(/\\'''/g, "\\'"); // remove non-escaped single-quote if there are enclosed between 2 escaped
-    }
-    return value;
+    return `'${value.replace(/'/g, "'\\''")}'`
+        .replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
+        .replace(/\\'''/g, "\\'"); // remove non-escaped single-quote if there are enclosed between 2 escaped
 }
 exports.default = shellEscape;
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4547,7 +4547,11 @@ function run() {
             const token = core.getInput('token', { required: false });
             const filtersInput = core.getInput('filters', { required: true });
             const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput;
-            const exportFormat = core.getInput('list-files', { required: false }) || 'none';
+            const listFiles = core.getInput('list-files', { required: false }).toLowerCase() || 'none';
+            if (!isExportFormat(listFiles)) {
+                core.setFailed(`Input parameter 'list-files' is set to invalid value '${listFiles}'`);
+                return;
+            }
             const filter = new filter_1.Filter(filtersYaml);
             const files = yield getChangedFiles(token);
             if (files === null) {
@@ -4556,7 +4560,7 @@ function run() {
             }
             else {
                 const results = filter.match(files);
-                exportResults(results, exportFormat);
+                exportResults(results, listFiles);
             }
         }
         catch (error) {
@@ -4697,6 +4701,9 @@ function serializeExport(files, format) {
         default:
             return '';
     }
+}
+function isExportFormat(value) {
+    return value === 'none' || value === 'shell' || value === 'json';
 }
 run();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,8 +155,9 @@ function exportResults(results: FilterResults, format: ExportFormat): void {
   for (const [key, files] of Object.entries(results)) {
     const value = files.length > 0
     core.startGroup(`Filter ${key} = ${value}`)
+    core.info('Matching files:')
     for (const file of files) {
-      core.info(`Matched file: ${file.filename} [${file.status}]`)
+      core.info(`${file.filename} [${file.status}]`)
     }
 
     core.setOutput(key, value)

--- a/src/shell-escape.ts
+++ b/src/shell-escape.ts
@@ -1,14 +1,7 @@
 // Credits to https://github.com/xxorax/node-shell-escape
 
-const needEscape = /[^A-Za-z0-9_/:=-]/
-
 export default function shellEscape(value: string): string {
-  if (needEscape.test(value)) {
-    value = `'${value.replace(/'/g, "'\\''")}'`
-    value = value
-      .replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
-      .replace(/\\'''/g, "\\'") // remove non-escaped single-quote if there are enclosed between 2 escaped
-  }
-
-  return value
+  return `'${value.replace(/'/g, "'\\''")}'`
+    .replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
+    .replace(/\\'''/g, "\\'") // remove non-escaped single-quote if there are enclosed between 2 escaped
 }

--- a/src/shell-escape.ts
+++ b/src/shell-escape.ts
@@ -1,0 +1,14 @@
+// Credits to https://github.com/xxorax/node-shell-escape
+
+const needEscape = /[^A-Za-z0-9_/:=-]/
+
+export default function shellEscape(value: string): string {
+  if (needEscape.test(value)) {
+    value = `'${value.replace(/'/g, "'\\''")}'`
+    value = value
+      .replace(/^(?:'')+/g, '') // unduplicate single-quote at the beginning
+      .replace(/\\'''/g, "\\'") // remove non-escaped single-quote if there are enclosed between 2 escaped
+  }
+
+  return value
+}


### PR DESCRIPTION
Optionally adds additional output variable for each rule, set to list of matching files.
Paths are formatted either as JSON array or escaped and space delimited for usage in shell scripts.
Output format is controlled by `list-files` input parameter. By default it's `none`, which disables listing of matching files.

This should support @robdodson use-case in #20 