### PR TITLE
Change detection using git "three dot" diff

### DIFF
--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -75,8 +75,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: touch add.txt && rm README.md && echo "TEST" > LICENSE
-    - run: git add -A && git commit -a -m 'testing this action' --author='John Doe <john@nowhere.local>'
+    - name: configure GIT user
+      run: git config user.email "john@nowhere.local" && git config user.name "John Doe"
+    - name: modify working tree
+      run: touch add.txt && rm README.md && echo "TEST" > LICENSE
+    - name: commit changes
+      run: git add -A && git commit -a -m 'testing this action'
     - uses: ./
       id: filter
       with:

--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: touch add.txt && rm README.md && echo "TEST" > LICENSE
-    - run: git add -A && git commit -a -m 'testing this action'
+    - run: git add -A && git commit -a -m 'testing this action' --author='John Doe <john@nowhere.local>'
     - uses: ./
       id: filter
       with:

--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -75,7 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: touch add.txt && rm README.md && echo "TEST" > LICENSE && git add -A
+    - run: touch add.txt && rm README.md && echo "TEST" > LICENSE
+    - run: git add -A && git commit -a -m 'testing this action'
     - uses: ./
       id: filter
       with:

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -1,18 +1,11 @@
 import * as git from '../src/git'
-import {ExecOptions} from '@actions/exec'
 import {ChangeStatus} from '../src/file'
 
-describe('parsing of the git diff-index command', () => {
-  test('getChangedFiles returns files with correct change status', async () => {
-    const files = await git.getChangedFiles(git.FETCH_HEAD, (cmd, args, opts) => {
-      const stdout = opts?.listeners?.stdout
-      if (stdout) {
-        stdout(Buffer.from('A\u0000LICENSE\u0000'))
-        stdout(Buffer.from('M\u0000src/index.ts\u0000'))
-        stdout(Buffer.from('D\u0000src/main.ts\u0000'))
-      }
-      return Promise.resolve(0)
-    })
+describe('parsing output of the git diff command', () => {
+  test('parseGitDiffOutput returns files with correct change status', async () => {
+    const files = git.parseGitDiffOutput(
+      'A\u0000LICENSE\u0000' + 'M\u0000src/index.ts\u0000' + 'D\u0000src/main.ts\u0000'
+    )
     expect(files.length).toBe(3)
     expect(files[0].filename).toBe('LICENSE')
     expect(files[0].status).toBe(ChangeStatus.Added)

--- a/action.yml
+++ b/action.yml
@@ -17,15 +17,23 @@ inputs:
     required: false
   filters:
     description: 'Path to the configuration file or YAML string with filters definition'
-    required: false
+    required: true
   list-files:
     description: |
       Enables listing of files matching the filter:
         'none'  - Disables listing of matching files (default).
         'json'  - Matching files paths are serialized as JSON array.
         'shell' - Matching files paths are escaped and space-delimited. Output is usable as command line argument list in linux shell.
-    required: false
+    required: true
     default: none
+  initial-fetch-depth:
+    description: |
+      How many commits are initially fetched from base branch.
+      If needed, each subsequent fetch doubles the previously requested number of commits
+      until the merge-base is found or there are no more commits in the history.
+      This option takes effect only when changes are detected using git against different base branch.
+    required: false
+    default: '10'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -3933,11 +3933,16 @@ function trimRefsHeads(ref) {
 exports.trimRefsHeads = trimRefsHeads;
 function tryDeepen(ref, deepen) {
     return __awaiter(this, void 0, void 0, function* () {
-        const before = (yield getNumberOfCommits('HEAD')) + (yield getNumberOfCommits(ref));
-        yield exec_1.exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '-q']);
-        const after = (yield getNumberOfCommits('HEAD')) + (yield getNumberOfCommits(ref));
-        // Check if have more commits now
-        return after > before;
+        const headBefore = yield getNumberOfCommits('HEAD');
+        const refBefore = yield getNumberOfCommits(ref);
+        yield exec_1.exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '--no-auto-gc', '-q']);
+        const headAfter = yield getNumberOfCommits('HEAD');
+        const refAfter = yield getNumberOfCommits(ref);
+        const headFetched = headAfter - headBefore;
+        const refFetched = refBefore - refAfter;
+        core.info(`HEAD -> ${headFetched} commits fetched.`);
+        core.info(`${ref} -> ${refFetched} commits fetched.`);
+        return headFetched > 0 || refFetched > 0;
     });
 }
 function getNumberOfCommits(ref) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3945,10 +3945,11 @@ function getNumberOfCommits(ref) {
         let output = '';
         yield exec_1.exec('git', ['rev-list', `--count`, ref], {
             listeners: {
-                stderr: (data) => (output += data.toString())
+                stdout: (data) => (output += data.toString())
             }
         });
-        return parseInt(output);
+        const count = parseInt(output);
+        return isNaN(count) ? 0 : count;
     });
 }
 function trimStart(ref, start) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3874,7 +3874,8 @@ function getChangesSinceRef(ref, initialFetchDepth = 10) {
             }
             // Try to fetch more commits
             // If there are none, it means there is no common history between base and HEAD
-            if (!tryDeepen(deepen)) {
+            if (deepen > Number.MAX_SAFE_INTEGER || !tryDeepen(deepen)) {
+                core.info('No merge base found - all files will be listed as added');
                 return listAllFilesAsAdded();
             }
             deepen = deepen * 2;
@@ -3927,13 +3928,13 @@ function trimRefsHeads(ref) {
 exports.trimRefsHeads = trimRefsHeads;
 function tryDeepen(deepen) {
     return __awaiter(this, void 0, void 0, function* () {
-        let output = '';
+        let error = '';
         yield exec_1.exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags'], {
             listeners: {
-                stdout: (data) => (output += data.toString())
+                stderr: (data) => (error += data.toString())
             }
         });
-        return !output.includes('remote: Total 0 ');
+        return !error.includes('remote: Total 0 ');
     });
 }
 function trimStart(ref, start) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3851,12 +3851,14 @@ function getChangesSinceRef(ref, initialFetchDepth = 10) {
         let deepen = initialFetchDepth;
         for (;;) {
             let output = '';
+            let error = '';
             let exitCode;
             try {
                 exitCode = yield exec_1.exec('git', ['diff', '--no-renames', '--name-status', '-z', `${ref}...HEAD`], {
                     ignoreReturnCode: true,
                     listeners: {
-                        stdout: (data) => (output += data.toString())
+                        stdout: (data) => (output += data.toString()),
+                        stderr: (data) => (error += data.toString())
                     }
                 });
             }
@@ -3867,7 +3869,7 @@ function getChangesSinceRef(ref, initialFetchDepth = 10) {
                 return parseGitDiffOutput(output);
             }
             // Only acceptable error is when there is no merge base
-            if (!output.includes('no merge base')) {
+            if (!error.includes('no merge base')) {
                 throw new Error('Unexpected failure of `git diff` command');
             }
             // Try to fetch more commits

--- a/dist/index.js
+++ b/dist/index.js
@@ -3834,18 +3834,28 @@ exports.getChangesAgainstSha = getChangesAgainstSha;
 async function getChangesSinceRef(ref, initialFetchDepth = 10) {
     // Fetch and add base branch
     await exec_1.exec('git', ['fetch', `--depth=${initialFetchDepth}`, '--no-tags', 'origin', `${ref}:${ref}`]);
-    // Fetch older commits until merge-base is found
-    for (let deepen = initialFetchDepth;; deepen *= 2) {
-        const exitCode = await exec_1.exec('git', ['merge-base', ref, 'HEAD'], { ignoreReturnCode: true });
-        if (exitCode === 0) {
-            // merge-base was found
-            break;
-        }
-        if (deepen > Number.MAX_SAFE_INTEGER || !tryDeepen(ref, deepen)) {
-            core.info('No merge base found - all files will be listed as added');
-            return listAllFilesAsAdded();
-        }
+    async function hasMergeBase() {
+        return (await exec_1.exec('git', ['merge-base', ref, 'HEAD'], { ignoreReturnCode: true })) === 0;
     }
+    async function countCommits() {
+        return (await getNumberOfCommits('HEAD')) + (await getNumberOfCommits(ref));
+    }
+    // Fetch more commits until merge-base is found
+    if (!(await hasMergeBase())) {
+        let deepen = initialFetchDepth;
+        let lastCommitsCount = await countCommits();
+        do {
+            await exec_1.exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '--no-auto-gc', '-q']);
+            const count = await countCommits();
+            if (count <= lastCommitsCount) {
+                core.info('No merge base found - all files will be listed as added');
+                return await listAllFilesAsAdded();
+            }
+            lastCommitsCount = count;
+            deepen = Math.min(deepen * 2, Number.MAX_SAFE_INTEGER);
+        } while (!(await hasMergeBase()));
+    }
+    // Get changes introduced on HEAD compared to ref
     let output = '';
     try {
         await exec_1.exec('git', ['diff', '--no-renames', '--name-status', '-z', `${ref}...HEAD`], {
@@ -3906,18 +3916,6 @@ function trimRefsHeads(ref) {
     return trimStart(trimRef, 'heads/');
 }
 exports.trimRefsHeads = trimRefsHeads;
-async function tryDeepen(ref, deepen) {
-    const headBefore = await getNumberOfCommits('HEAD');
-    const refBefore = await getNumberOfCommits(ref);
-    await exec_1.exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '--no-auto-gc']);
-    const headAfter = await getNumberOfCommits('HEAD');
-    const refAfter = await getNumberOfCommits(ref);
-    const headFetched = headAfter - headBefore;
-    const refFetched = refBefore - refAfter;
-    core.info(`HEAD -> ${headFetched} commits fetched.`);
-    core.info(`${ref} -> ${refFetched} commits fetched.`);
-    return headFetched > 0 || refFetched > 0;
-}
 async function getNumberOfCommits(ref) {
     let output = '';
     await exec_1.exec('git', ['rev-list', `--count`, ref], {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3862,7 +3862,7 @@ function getChangesSinceRef(ref, initialFetchDepth = 10) {
         try {
             yield exec_1.exec('git', ['diff', '--no-renames', '--name-status', '-z', `${ref}...HEAD`], {
                 listeners: {
-                    stdout: (data) => (output += data.toString()),
+                    stdout: (data) => (output += data.toString())
                 }
             });
         }
@@ -3925,7 +3925,7 @@ function tryDeepen(ref, deepen) {
     return __awaiter(this, void 0, void 0, function* () {
         const headBefore = yield getNumberOfCommits('HEAD');
         const refBefore = yield getNumberOfCommits(ref);
-        yield exec_1.exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '--no-auto-gc', '-q']);
+        yield exec_1.exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '--no-auto-gc']);
         const headAfter = yield getNumberOfCommits('HEAD');
         const refAfter = yield getNumberOfCommits(ref);
         const headFetched = headAfter - headBefore;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3898,11 +3898,16 @@ exports.parseGitDiffOutput = parseGitDiffOutput;
 function listAllFilesAsAdded() {
     return __awaiter(this, void 0, void 0, function* () {
         let output = '';
-        yield exec_1.exec('git', ['ls-files', '-z'], {
-            listeners: {
-                stdout: (data) => (output += data.toString())
-            }
-        });
+        try {
+            yield exec_1.exec('git', ['ls-files', '-z'], {
+                listeners: {
+                    stdout: (data) => (output += data.toString())
+                }
+            });
+        }
+        finally {
+            fixStdOutNullTermination();
+        }
         return output
             .split('\u0000')
             .filter(s => s.length > 0)
@@ -3928,8 +3933,11 @@ function trimRefsHeads(ref) {
 exports.trimRefsHeads = trimRefsHeads;
 function tryDeepen(deepen) {
     return __awaiter(this, void 0, void 0, function* () {
+        // The only indicator there is no more history I've found.
+        // It forces the progress indicator and checks for 0 items from remote.
+        // If you know something better please open PR with fix.
         let error = '';
-        yield exec_1.exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags'], {
+        yield exec_1.exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '--progress'], {
             listeners: {
                 stderr: (data) => (error += data.toString())
             }

--- a/src/git.ts
+++ b/src/git.ts
@@ -32,12 +32,14 @@ export async function getChangesSinceRef(ref: string, initialFetchDepth = 10): P
   let deepen = initialFetchDepth
   for (;;) {
     let output = ''
+    let error = ''
     let exitCode
     try {
       exitCode = await exec('git', ['diff', '--no-renames', '--name-status', '-z', `${ref}...HEAD`], {
         ignoreReturnCode: true,
         listeners: {
-          stdout: (data: Buffer) => (output += data.toString())
+          stdout: (data: Buffer) => (output += data.toString()),
+          stderr: (data: Buffer) => (error += data.toString())
         }
       })
     } finally {
@@ -49,7 +51,7 @@ export async function getChangesSinceRef(ref: string, initialFetchDepth = 10): P
     }
 
     // Only acceptable error is when there is no merge base
-    if (!output.includes('no merge base')) {
+    if (!error.includes('no merge base')) {
       throw new Error('Unexpected failure of `git diff` command')
     }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -57,7 +57,8 @@ export async function getChangesSinceRef(ref: string, initialFetchDepth = 10): P
 
     // Try to fetch more commits
     // If there are none, it means there is no common history between base and HEAD
-    if (!tryDeepen(deepen)) {
+    if (deepen > Number.MAX_SAFE_INTEGER || !tryDeepen(deepen)) {
+      core.info('No merge base found - all files will be listed as added')
       return listAllFilesAsAdded()
     }
 
@@ -108,13 +109,13 @@ export function trimRefsHeads(ref: string): string {
 }
 
 async function tryDeepen(deepen: number): Promise<boolean> {
-  let output = ''
+  let error = ''
   await exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags'], {
     listeners: {
-      stdout: (data: Buffer) => (output += data.toString())
+      stderr: (data: Buffer) => (error += data.toString())
     }
   })
-  return !output.includes('remote: Total 0 ')
+  return !error.includes('remote: Total 0 ')
 }
 
 function trimStart(ref: string, start: string): string {

--- a/src/git.ts
+++ b/src/git.ts
@@ -104,7 +104,7 @@ export function trimRefsHeads(ref: string): string {
 async function tryDeepen(ref: string, deepen: number): Promise<boolean> {
   const headBefore = await getNumberOfCommits('HEAD')
   const refBefore = await getNumberOfCommits(ref)
-  await exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '--no-auto-gc', '-q'])
+  await exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '--no-auto-gc'])
   const headAfter = await getNumberOfCommits('HEAD')
   const refAfter = await getNumberOfCommits(ref)
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -113,12 +113,18 @@ export function trimRefsHeads(ref: string): string {
 }
 
 async function tryDeepen(ref: string, deepen: number): Promise<boolean> {
-  const before = (await getNumberOfCommits('HEAD')) + (await getNumberOfCommits(ref))
-  await exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '-q'])
-  const after = (await getNumberOfCommits('HEAD')) + (await getNumberOfCommits(ref))
+  const headBefore = await getNumberOfCommits('HEAD')
+  const refBefore = await getNumberOfCommits(ref)
+  await exec('git', ['fetch', `--deepen=${deepen}`, '--no-tags', '--no-auto-gc', '-q'])
+  const headAfter = await getNumberOfCommits('HEAD')
+  const refAfter = await getNumberOfCommits(ref)
 
-  // Check if have more commits now
-  return after > before
+  const headFetched = headAfter - headBefore
+  const refFetched = refBefore - refAfter
+  core.info(`HEAD -> ${headFetched} commits fetched.`)
+  core.info(`${ref} -> ${refFetched} commits fetched.`)
+
+  return headFetched > 0 || refFetched > 0
 }
 
 async function getNumberOfCommits(ref: string): Promise<number> {

--- a/src/git.ts
+++ b/src/git.ts
@@ -11,6 +11,7 @@ export async function getChangesAgainstSha(sha: string): Promise<File[]> {
   // Get differences between sha and HEAD
   let output = ''
   try {
+    // Two dots '..' change detection - directly compares two versions
     await exec('git', ['diff', '--no-renames', '--name-status', '-z', `${sha}..HEAD`], {
       listeners: {
         stdout: (data: Buffer) => (output += data.toString())
@@ -23,7 +24,7 @@ export async function getChangesAgainstSha(sha: string): Promise<File[]> {
   return parseGitDiffOutput(output)
 }
 
-export async function getChangesSinceRef(ref: string, initialFetchDepth = 10): Promise<File[]> {
+export async function getChangesSinceRef(ref: string, initialFetchDepth: number): Promise<File[]> {
   // Fetch and add base branch
   await exec('git', ['fetch', `--depth=${initialFetchDepth}`, '--no-tags', 'origin', `${ref}:${ref}`])
 
@@ -54,6 +55,7 @@ export async function getChangesSinceRef(ref: string, initialFetchDepth = 10): P
   // Get changes introduced on HEAD compared to ref
   let output = ''
   try {
+    // Three dots '...' change detection - finds merge-base and compares against it
     await exec('git', ['diff', '--no-renames', '--name-status', '-z', `${ref}...HEAD`], {
       listeners: {
         stdout: (data: Buffer) => (output += data.toString())

--- a/src/git.ts
+++ b/src/git.ts
@@ -125,10 +125,11 @@ async function getNumberOfCommits(ref: string): Promise<number> {
   let output = ''
   await exec('git', ['rev-list', `--count`, ref], {
     listeners: {
-      stderr: (data: Buffer) => (output += data.toString())
+      stdout: (data: Buffer) => (output += data.toString())
     }
   })
-  return parseInt(output)
+  const count = parseInt(output)
+  return isNaN(count) ? 0 : count
 }
 
 function trimStart(ref: string, start: string): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -139,12 +139,17 @@ async function getChangedFilesFromApi(
 }
 
 function exportResults(results: FilterResults, format: ExportFormat): void {
+  core.info('Results:')
   for (const [key, files] of Object.entries(results)) {
     const value = files.length > 0
     core.startGroup(`Filter ${key} = ${value}`)
-    core.info('Matching files:')
-    for (const file of files) {
-      core.info(`${file.filename} [${file.status}]`)
+    if (files.length > 0) {
+      core.info('Matching files:')
+      for (const file of files) {
+        core.info(`${file.filename} [${file.status}]`)
+      }
+    } else {
+      core.info('Matching files: none')
     }
 
     core.setOutput(key, value)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "es2019",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "outDir": "./lib",                        /* Redirect output structure to the directory. */
     "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */


### PR DESCRIPTION
Git provides "two" and "three" dots diffs
-  *two dots*: changes between two arbitrary commits 
- *three dots*: finds merge-base (common ancestor) and diffs against it.

Previously only "two dots" diff was used.
This caused troubles when diffing against the base branch. Changes introduced by newer commits on the base branch were detected while they should be ignored.

This PR fixes this by introducing on-demand fetching of history and then using "three dots" diff to detect changes made only on the current branch. Documentation will be updated in separate PR before releasing next version.

Fixes #33 

