### PR TITLE
v2.4.0 - support local execution with act

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v2.4.0
+- [Support pushes of tags or when tag is used as base](https://github.com/dorny/paths-filter/pull/40)
+- [Use git log to detect changes from PRs merge commit if token is not available](https://github.com/dorny/paths-filter/pull/40)
+- [Support local execution with act](https://github.com/dorny/paths-filter/pull/40)
+- [Improved processing of repository initial push](https://github.com/dorny/paths-filter/pull/40)
+- [Improved processing of first push of new branch](https://github.com/dorny/paths-filter/pull/40)
+
+
 ## v2.3.0
 - [Improved documentation](https://github.com/dorny/paths-filter/pull/37)
 - [Change detection using git "three dot" diff](https://github.com/dorny/paths-filter/pull/35)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ doesn't allow this because they doesn't work on a level of individual jobs or st
 
 
 # What's New
-
+- Support for tag pushes and tags as a base reference
+- Fixes for various edge cases when event payload is incomplete
+  - Now works locally with [act](https://github.com/nektos/act)
 - Fixed behavior of feature branch workflow:
   - Detects only changes introduced by feature branch. Later modifications on base branch are ignored.
 - Filter by type of file change:
@@ -68,7 +70,7 @@ For more information see [CHANGELOG](https://github.com/actions/checkout/blob/ma
     # Filters syntax is documented by example - see examples section.
     filters: ''
 
-    # Branch against which the changes will be detected.
+    # Branch or tag against which the changes will be detected.
     # If it references same branch it was pushed to,
     # changes are detected against the most recent commit before the push.
     # Otherwise it uses git merge-base to find best common ancestor between

--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ doesn't allow this because they doesn't work on a level of individual jobs or st
 - Minimatch [dot](https://www.npmjs.com/package/minimatch#dot) option is set to true.
   Globbing will match also paths where file or folder name starts with a dot.
 - It's recommended to quote your path expressions with `'` or `"`. Otherwise you will get an error if it starts with `*`.
+- Local execution with [act](https://github.com/nektos/act) works only with alternative runner image. Default runner doesn't have `git` binary.
+  - Use: `act -P ubuntu-latest=nektos/act-environments-ubuntu:18.04`
 
 
 # What's New
 - Support for tag pushes and tags as a base reference
 - Fixes for various edge cases when event payload is incomplete
-  - Now works locally with [act](https://github.com/nektos/act)
+  - Supports local execution with [act](https://github.com/nektos/act)
 - Fixed behavior of feature branch workflow:
   - Detects only changes introduced by feature branch. Later modifications on base branch are ignored.
 - Filter by type of file change:

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -17,19 +17,9 @@ describe('parsing output of the git diff command', () => {
 })
 
 describe('git utility function tests (those not invoking git)', () => {
-  test('Detects if ref references a tag', () => {
-    expect(git.isTagRef('refs/tags/v1.0')).toBeTruthy()
-    expect(git.isTagRef('refs/heads/master')).toBeFalsy()
-    expect(git.isTagRef('master')).toBeFalsy()
-  })
-  test('Trims "refs/" from ref', () => {
-    expect(git.trimRefs('refs/heads/master')).toBe('heads/master')
-    expect(git.trimRefs('heads/master')).toBe('heads/master')
-    expect(git.trimRefs('master')).toBe('master')
-  })
   test('Trims "refs/" and "heads/" from ref', () => {
-    expect(git.trimRefsHeads('refs/heads/master')).toBe('master')
-    expect(git.trimRefsHeads('heads/master')).toBe('master')
-    expect(git.trimRefsHeads('master')).toBe('master')
+    expect(git.getShortName('refs/heads/master')).toBe('master')
+    expect(git.getShortName('heads/master')).toBe('master')
+    expect(git.getShortName('master')).toBe('master')
   })
 })

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -19,7 +19,11 @@ describe('parsing output of the git diff command', () => {
 describe('git utility function tests (those not invoking git)', () => {
   test('Trims "refs/" and "heads/" from ref', () => {
     expect(git.getShortName('refs/heads/master')).toBe('master')
-    expect(git.getShortName('heads/master')).toBe('master')
+    expect(git.getShortName('heads/master')).toBe('heads/master')
     expect(git.getShortName('master')).toBe('master')
+
+    expect(git.getShortName('refs/tags/v1')).toBe('v1')
+    expect(git.getShortName('tags/v1')).toBe('tags/v1')
+    expect(git.getShortName('v1')).toBe('v1')
   })
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -4677,9 +4677,6 @@ async function getChangedFilesFromPush(base, initialFetchDepth) {
     const pushRef = git.getShortName(push.ref) ||
         (core.warning(`'ref' field is missing in PUSH event payload - using current branch, tag or commit SHA`),
             await git.getCurrentRef());
-    const beforeRef = push.before ||
-        (core.warning(`'before' field is missing in PUSH event payload - using parent of current commit`),
-            await git.getParentSha(pushRef));
     const baseRef = git.getShortName(base) || defaultRef;
     if (!baseRef) {
         throw new Error("This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload");
@@ -4687,6 +4684,9 @@ async function getChangedFilesFromPush(base, initialFetchDepth) {
     // If base references same branch it was pushed to,
     // we will do comparison against the previously pushed commit
     if (baseRef === pushRef) {
+        const beforeRef = push.before ||
+            (core.warning(`'before' field is missing in PUSH event payload - using parent of current commit`),
+                await git.getParentSha(pushRef));
         // If there is no previously pushed commit,
         // we will do comparison against the default branch or return all as added
         if (beforeRef === git.NULL_SHA) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3820,7 +3820,7 @@ async function getChangesInLastCommit() {
     core.startGroup(`Change detection in last commit`);
     let output = '';
     try {
-        output = (await exec_1.default('git', ['log', '--no-renames', '--name-status', '-z', '-n', '1'])).stdout;
+        output = (await exec_1.default('git', ['log', '--format=', '--no-renames', '--name-status', '-z', '-n', '1'])).stdout;
     }
     finally {
         fixStdOutNullTermination();

--- a/dist/index.js
+++ b/dist/index.js
@@ -4673,7 +4673,11 @@ function getConfigFileContent(configPath) {
 async function getChangedFiles(token, base, initialFetchDepth) {
     if (github.context.eventName === 'pull_request' || github.context.eventName === 'pull_request_target') {
         const pr = github.context.payload.pull_request;
-        return token ? await getChangedFilesFromApi(token, pr) : await git.getChangesInLastCommit(); // For PRs there will be detached head with merge commit
+        if (token) {
+            return await getChangedFilesFromApi(token, pr);
+        }
+        core.info('Github token is not available - changes will be detected from PRs merge commit');
+        return await git.getChangesInLastCommit();
     }
     else if (github.context.eventName === 'push') {
         return getChangedFilesFromPush(base, initialFetchDepth);
@@ -4689,7 +4693,7 @@ async function getChangedFilesFromPush(base, initialFetchDepth) {
     const pushRef = git.getShortName(push.ref) ||
         (core.warning(`'ref' field is missing in PUSH event payload - using current branch, tag or commit SHA`),
             await git.getCurrentRef());
-    const baseRef = base || defaultRef;
+    const baseRef = git.getShortName(base) || defaultRef;
     if (!baseRef) {
         throw new Error("This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload");
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -3934,7 +3934,7 @@ async function getParentSha(ref) {
         .split('\n')
         .filter(line => line.startsWith(parent))
         .map(line => line.slice(parent.length).trim());
-    return parents[0];
+    return parents.length > 0 ? parents[0] : exports.NULL_SHA;
 }
 exports.getParentSha = getParentSha;
 function getShortName(ref) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3838,7 +3838,7 @@ async function getChanges(ref) {
 }
 exports.getChanges = getChanges;
 async function getChangesSinceMergeBase(ref, initialFetchDepth) {
-    if (!(await hasBranch(ref))) {
+    if (!(await hasRef(ref))) {
         // Fetch and add base branch
         core.startGroup(`Fetching ${ref} from origin until merge-base is found`);
         await exec_1.default('git', ['fetch', `--depth=${initialFetchDepth}`, '--no-tags', 'origin', `${ref}:${ref}`]);
@@ -3970,8 +3970,8 @@ async function hasCommit(ref) {
         core.endGroup();
     }
 }
-async function hasBranch(branch) {
-    const showRef = await exec_1.default('git', ['show-ref', '--verify', '-q', `refs/heads/${branch}`], { ignoreReturnCode: true });
+async function hasRef(ref) {
+    const showRef = await exec_1.default('git', ['show-ref', '--verify', '-q', ref], { ignoreReturnCode: true });
     return showRef.code === 0;
 }
 async function getNumberOfCommits(ref) {

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,0 +1,21 @@
+import {exec as execImpl , ExecOptions} from '@actions/exec'
+
+// Wraps original exec() function
+// Returns exit code and whole stdout/stderr
+export default async function exec(commandLine: string, args?: string[], options?: ExecOptions): Promise<ExecResult> {
+  options = options || {}
+  let stdout = ''
+  let stderr = ''
+  options.listeners = {
+    stdout: (data: Buffer) => (stdout += data.toString()),
+    stderr: (data: Buffer) => (stderr += data.toString())
+  }
+  const code = await execImpl(commandLine, args, options)
+  return { code, stdout, stderr }
+}
+
+export type ExecResult = {
+  code: number,
+  stdout: string,
+  stderr: string
+}

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,4 +1,4 @@
-import {exec as execImpl , ExecOptions} from '@actions/exec'
+import {exec as execImpl, ExecOptions} from '@actions/exec'
 
 // Wraps original exec() function
 // Returns exit code and whole stdout/stderr
@@ -11,11 +11,11 @@ export default async function exec(commandLine: string, args?: string[], options
     stderr: (data: Buffer) => (stderr += data.toString())
   }
   const code = await execImpl(commandLine, args, options)
-  return { code, stdout, stderr }
+  return {code, stdout, stderr}
 }
 
-export type ExecResult = {
-  code: number,
-  stdout: string,
+export interface ExecResult {
+  code: number
+  stdout: string
   stderr: string
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -130,7 +130,8 @@ export async function getParentSha(ref: string): Promise<string> {
     .split('\n')
     .filter(line => line.startsWith(parent))
     .map(line => line.slice(parent.length).trim())
-  return parents[0]
+
+  return parents.length > 0 ? parents[0] : NULL_SHA
 }
 
 export function getShortName(ref: string): string {

--- a/src/git.ts
+++ b/src/git.ts
@@ -27,7 +27,7 @@ export async function getChanges(ref: string): Promise<File[]> {
 }
 
 export async function getChangesSinceMergeBase(ref: string, initialFetchDepth: number): Promise<File[]> {
-  if (!(await hasBranch(ref))) {
+  if (!(await hasRef(ref))) {
     // Fetch and add base branch
     core.startGroup(`Fetching ${ref} from origin until merge-base is found`)
     await exec('git', ['fetch', `--depth=${initialFetchDepth}`, '--no-tags', 'origin', `${ref}:${ref}`])
@@ -165,8 +165,8 @@ async function hasCommit(ref: string): Promise<boolean> {
   }
 }
 
-async function hasBranch(branch: string): Promise<boolean> {
-  const showRef = await exec('git', ['show-ref', '--verify', '-q', `refs/heads/${branch}`], {ignoreReturnCode: true})
+async function hasRef(ref: string): Promise<boolean> {
+  const showRef = await exec('git', ['show-ref', '--verify', '-q', ref], {ignoreReturnCode: true})
   return showRef.code === 0
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -8,7 +8,7 @@ export async function getChangesInLastCommit(): Promise<File[]> {
   core.startGroup(`Change detection in last commit`)
   let output = ''
   try {
-    output = (await exec('git', ['log', '--no-renames', '--name-status', '-z', '-n', '1'])).stdout
+    output = (await exec('git', ['log', '--format=', '--no-renames', '--name-status', '-z', '-n', '1'])).stdout
   } finally {
     fixStdOutNullTermination()
     core.endGroup()

--- a/src/git.ts
+++ b/src/git.ts
@@ -112,7 +112,7 @@ export async function getCurrentRef(): Promise<string> {
       return branch
     }
 
-    const describe = await exec('git', ['describe', '--all', '--exact-match'], {ignoreReturnCode: true})
+    const describe = await exec('git', ['describe', '--tags', '--exact-match'], {ignoreReturnCode: true})
     if (describe.code === 0) {
       return describe.stdout.trim()
     }
@@ -145,8 +145,15 @@ export async function getParentSha(ref: string): Promise<string> {
 }
 
 export function getShortName(ref: string): string {
-  const trimRef = trimStart(ref, 'refs/')
-  return trimStart(trimRef, 'heads/')
+  if (!ref) return ''
+
+  const heads = 'refs/heads/'
+  const tags = 'refs/tags/'
+
+  if (ref.startsWith(heads)) return ref.slice(heads.length)
+  if (ref.startsWith(tags)) return ref.slice(tags.length)
+
+  return ref
 }
 
 async function hasCommit(ref: string): Promise<boolean> {
@@ -167,13 +174,6 @@ async function getNumberOfCommits(ref: string): Promise<number> {
   const output = (await exec('git', ['rev-list', `--count`, ref])).stdout
   const count = parseInt(output)
   return isNaN(count) ? 0 : count
-}
-
-function trimStart(ref: string, start: string): string {
-  if (!ref) {
-    return ''
-  }
-  return ref.startsWith(start) ? ref.substr(start.length) : ref
 }
 
 function fixStdOutNullTermination(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,7 @@ async function getChangedFiles(token: string, base: string, initialFetchDepth: n
     const pr = github.context.payload.pull_request as Webhooks.WebhookPayloadPullRequestPullRequest
     return token
       ? await getChangedFilesFromApi(token, pr)
-      : await git.getChangesSinceRef(pr.base.ref, initialFetchDepth)
+      : await git.getChangesSinceMergeBase(pr.base.ref, initialFetchDepth)
   } else if (github.context.eventName === 'push') {
     return getChangedFilesFromPush(base, initialFetchDepth)
   } else {
@@ -69,30 +69,47 @@ async function getChangedFiles(token: string, base: string, initialFetchDepth: n
 
 async function getChangedFilesFromPush(base: string, initialFetchDepth: number): Promise<File[]> {
   const push = github.context.payload as Webhooks.WebhookPayloadPush
+  const defaultRef = push.repository?.default_branch
 
-  // No change detection for pushed tags
-  if (git.isTagRef(push.ref)) {
-    core.info('Workflow is triggered by pushing of tag - all files will be listed as added')
-    return await git.listAllFilesAsAdded()
+  const pushRef =
+    git.getShortName(push.ref) ||
+    (core.warning(`'ref' field is missing in PUSH event payload - using current branch, tag or commit SHA`),
+    await git.getCurrentRef())
+
+  const beforeRef =
+    push.before ||
+    (core.warning(`'before' field is missing in PUSH event payload - using parent of current commit`),
+    await git.getParentSha(pushRef))
+
+  const baseRef = git.getShortName(base) || defaultRef
+  if (!baseRef) {
+    throw new Error(
+      "This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload"
+    )
   }
 
-  const baseRef = git.trimRefsHeads(base || push.repository.default_branch)
-  const pushRef = git.trimRefsHeads(push.ref)
-
-  // If base references same branch it was pushed to, we will do comparison against the previously pushed commit.
+  // If base references same branch it was pushed to,
+  // we will do comparison against the previously pushed commit
   if (baseRef === pushRef) {
-    if (push.before === git.NULL_SHA) {
-      core.info('First push of a branch detected - all files will be listed as added')
-      return await git.listAllFilesAsAdded()
+    // If there is no previously pushed commit,
+    // we will do comparison against the default branch or return all as added
+    if (beforeRef === git.NULL_SHA) {
+      if (defaultRef && baseRef !== defaultRef) {
+        core.info(`First push of a branch detected - changes will be detected against the default branch ${defaultRef}`)
+        return await git.getChangesSinceMergeBase(defaultRef, initialFetchDepth)
+      } else {
+        core.info('Initial push detected - all files will be listed as added')
+        return await git.listAllFilesAsAdded()
+      }
     }
 
     core.info(`Changes will be detected against the last previously pushed commit on same branch (${pushRef})`)
-    return await git.getChangesAgainstSha(push.before)
+    return await git.getChanges(beforeRef)
   }
 
   // Changes introduced by current branch against the base branch
   core.info(`Changes will be detected against the branch ${baseRef}`)
-  return await git.getChangesSinceRef(baseRef, initialFetchDepth)
+  return await git.getChangesSinceMergeBase(baseRef, initialFetchDepth)
 }
 
 // Uses github REST api to get list of files changed in PR

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,11 +76,6 @@ async function getChangedFilesFromPush(base: string, initialFetchDepth: number):
     (core.warning(`'ref' field is missing in PUSH event payload - using current branch, tag or commit SHA`),
     await git.getCurrentRef())
 
-  const beforeRef =
-    push.before ||
-    (core.warning(`'before' field is missing in PUSH event payload - using parent of current commit`),
-    await git.getParentSha(pushRef))
-
   const baseRef = git.getShortName(base) || defaultRef
   if (!baseRef) {
     throw new Error(
@@ -91,6 +86,11 @@ async function getChangedFilesFromPush(base: string, initialFetchDepth: number):
   // If base references same branch it was pushed to,
   // we will do comparison against the previously pushed commit
   if (baseRef === pushRef) {
+    const beforeRef =
+      push.before ||
+      (core.warning(`'before' field is missing in PUSH event payload - using parent of current commit`),
+      await git.getParentSha(pushRef))
+
     // If there is no previously pushed commit,
     // we will do comparison against the default branch or return all as added
     if (beforeRef === git.NULL_SHA) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,7 @@ async function getChangedFilesFromPush(base: string, initialFetchDepth: number):
     (core.warning(`'ref' field is missing in PUSH event payload - using current branch, tag or commit SHA`),
     await git.getCurrentRef())
 
-  const baseRef = git.getShortName(base) || defaultRef
+  const baseRef = base || defaultRef
   if (!baseRef) {
     throw new Error(
       "This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload"


### PR DESCRIPTION
- Removed restriction to mark all as added when `push.ref` or `base` input refers to tag
- Use `git log` to detect changes from PRs merge commit when Github auth token is not available
- Improved processing of repository initial push:
  - all files are marked as added
- Improved processing of first push of new branch
  - if SHA of previous push is not available it will fallback to detect changes against merge-base with default branch
- Support local execution with [act](https://github.com/nektos/act)
  - Fallback behavior for missing event payload data
  - No requests to remote if all needed is already available locally - `act` images doesn't have proper git/ssh configuration against github so it would fail otherwise

Closes #39 
Closes #33 