### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ jobs:
 - name: Lint Markdown
   uses: johndoe/some-action@v1
   with:
-    files: ${{ steps.filter.changed_files }}
+    files: ${{ steps.filter.outputs.changed_files }}
 ```
 </details>
 


### PR DESCRIPTION
The example was missing `outputs`