### PR TITLE
feat: Add support for multiple patterns when using file status

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,10 +350,15 @@ jobs:
         # dictionary, where type(s) of change composes the key.
         # Multiple change types can be specified using `|` as delimiter.
         filters: |
+          shared: &shared
+            - common/**
+            - config/**
           addedOrModified:
             - added|modified: '**'
           allChanges:
             - added|deleted|modified: '**'
+          addedOrModifiedAnchors:
+            - added|modified: *shared
 ```
 </details>
 

--- a/__tests__/filter.test.ts
+++ b/__tests__/filter.test.ts
@@ -165,6 +165,20 @@ describe('matching specific change status', () => {
     const match = filter.match(files)
     expect(match.addOrModify).toEqual(files)
   })
+
+  test.only('matches when using an anchor', () => {
+    const yaml = `
+    shared: &shared
+      - common/**/*
+      - config/**/*
+    src:
+      - modified: *shared
+    `
+    let filter = new Filter(yaml)
+    const files = modified(['config/file.js', 'common/anotherFile.js'])
+    const match = filter.match(files)
+    expect(match.src).toEqual(files)
+  })
 })
 
 function modified(paths: string[]): File[] {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -78,7 +78,7 @@ export class Filter {
 
     if (typeof item === 'object') {
       return Object.entries(item).map(([key, pattern]) => {
-        if (typeof key !== 'string' || typeof pattern !== 'string') {
+        if (typeof key !== 'string' || (typeof pattern !== 'string' && !Array.isArray(pattern))) {
           this.throwInvalidFormatError(
             `Expected [key:string]= pattern:string, but [${key}:${typeof key}]= ${pattern}:${typeof pattern} found`
           )


### PR DESCRIPTION
This adds support for using multiple patterns when checking for file status (added, modified, deleted) and as a result also allows you to use YAML anchors.