### PR TITLE
fix: retrieve all changes via api

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import {Webhooks} from '@octokit/webhooks'
+import type {Octokit} from '@octokit/rest'
 
 import {Filter, FilterResults} from './filter'
 import {File, ChangeStatus} from './file'

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,8 +127,10 @@ async function getChangedFilesFromApi(
   const client = new github.GitHub(token)
   const pageSize = 100
   const files: File[] = []
-  for (let page = 0; page * pageSize < pullRequest.changed_files; page++) {
-    const response = await client.pulls.listFiles({
+  let response: Octokit.Response<Octokit.PullsListFilesResponse>
+  let page = 0
+  do {
+    response = await client.pulls.listFiles({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
       pull_number: pullRequest.number,
@@ -156,7 +158,8 @@ async function getChangedFilesFromApi(
         })
       }
     }
-  }
+    page++
+  } while (response?.data?.length > 0)
 
   return files
 }


### PR DESCRIPTION
the number returned by pullRequest.changed_files doesn't reflect the correct number of real changed files. Therefore lot of filters didn't work in my scenario, as it said nothing has changed. This especially happens if there are more than 100 files changed (first time I experienced it where over 1000 files have changed, and now when there were about 300 files that have changed). 

I changed the detection by querying the api as long as it returns new results. This ensures all pages have been retrieved. It's tested and used in production on our end, but please check again if I didn't miss anything.

Thanks a lot for this awesome github action :)