### PR TITLE
Fix change detection using Github API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v2.5.3
+- [Fixed mapping of removed/deleted change status from github API](https://github.com/dorny/paths-filter/pull/51)
 - [Fixed retrieval of all changes via Github API when there are 100+ changes](https://github.com/dorny/paths-filter/pull/50)
 
 ## v2.5.2

--- a/dist/index.js
+++ b/dist/index.js
@@ -4730,13 +4730,14 @@ async function getChangedFilesFromGit(base, initialFetchDepth) {
 // Uses github REST api to get list of files changed in PR
 async function getChangedFilesFromApi(token, pullRequest) {
     var _a;
-    core.info(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
+    core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
     const client = new github.GitHub(token);
     const pageSize = 100;
     const files = [];
     let response;
     let page = 0;
     do {
+        core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, page: ${page}, per_page: ${pageSize})`);
         response = await client.pulls.listFiles({
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
@@ -4745,6 +4746,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
             per_page: pageSize
         });
         for (const row of response.data) {
+            core.info(`[${row.status}] ${row.filename}`);
             // There's no obvious use-case for detection of renames
             // Therefore we treat it as if rename detection in git diff was turned off.
             // Rename is replaced by delete of original filename and add of new filename
@@ -4768,6 +4770,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
         }
         page++;
     } while (((_a = response === null || response === void 0 ? void 0 : response.data) === null || _a === void 0 ? void 0 : _a.length) > 0);
+    core.endGroup();
     return files;
 }
 function exportResults(results, format) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -4731,11 +4731,12 @@ async function getChangedFilesFromGit(base, initialFetchDepth) {
 async function getChangedFilesFromApi(token, pullRequest) {
     var _a;
     core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`);
+    core.info(`Declared number of changed_files = ${pullRequest.changed_files}`);
     const client = new github.GitHub(token);
     const pageSize = 100;
     const files = [];
     let response;
-    let page = 0;
+    let page = 1;
     do {
         core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, page: ${page}, per_page: ${pageSize})`);
         response = await client.pulls.listFiles({
@@ -4745,6 +4746,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
             page,
             per_page: pageSize
         });
+        core.info(`Headers: ${JSON.stringify(response.headers)}`);
         for (const row of response.data) {
             core.info(`[${row.status}] ${row.filename}`);
             // There's no obvious use-case for detection of renames

--- a/dist/index.js
+++ b/dist/index.js
@@ -4734,7 +4734,7 @@ async function getChangedFilesFromApi(token, pullRequest) {
     const client = new github.GitHub(token);
     const pageSize = 100;
     const files = [];
-    for (let page = 1; page * pageSize < pullRequest.changed_files; page++) {
+    for (let page = 1; (page - 1) * pageSize < pullRequest.changed_files; page++) {
         core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, page: ${page}, per_page: ${pageSize})`);
         const response = await client.pulls.listFiles({
             owner: github.context.repo.owner,

--- a/dist/index.js
+++ b/dist/index.js
@@ -4760,9 +4760,11 @@ async function getChangedFilesFromApi(token, pullRequest) {
                 });
             }
             else {
+                // Github status and git status variants are same except for deleted files
+                const status = row.status === 'removed' ? file_1.ChangeStatus.Deleted : row.status;
                 files.push({
                     filename: row.filename,
-                    status: row.status
+                    status
                 });
             }
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -4743,7 +4743,6 @@ async function getChangedFilesFromApi(token, pullRequest) {
             owner: github.context.repo.owner,
             repo: github.context.repo.repo,
             pull_number: pullRequest.number,
-            page,
             per_page: pageSize
         });
         core.info(`Headers: ${JSON.stringify(response.headers)}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,11 +125,12 @@ async function getChangedFilesFromApi(
   pullRequest: Webhooks.WebhookPayloadPullRequestPullRequest
 ): Promise<File[]> {
   core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`)
+  core.info(`Declared number of changed_files = ${pullRequest.changed_files}`)
   const client = new github.GitHub(token)
   const pageSize = 100
   const files: File[] = []
   let response: Octokit.Response<Octokit.PullsListFilesResponse>
-  let page = 0
+  let page = 1
   do {
     core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, page: ${page}, per_page: ${pageSize})`)
     response = await client.pulls.listFiles({
@@ -139,6 +140,7 @@ async function getChangedFilesFromApi(
       page,
       per_page: pageSize
     })
+    core.info(`Headers: ${JSON.stringify(response.headers)}`)
     for (const row of response.data) {
       core.info(`[${row.status}] ${row.filename}`)
       // There's no obvious use-case for detection of renames

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,7 +137,6 @@ async function getChangedFilesFromApi(
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
       pull_number: pullRequest.number,
-      page,
       per_page: pageSize
     })
     core.info(`Headers: ${JSON.stringify(response.headers)}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,13 +124,14 @@ async function getChangedFilesFromApi(
   token: string,
   pullRequest: Webhooks.WebhookPayloadPullRequestPullRequest
 ): Promise<File[]> {
-  core.info(`Fetching list of changed files for PR#${pullRequest.number} from Github API`)
+  core.startGroup(`Fetching list of changed files for PR#${pullRequest.number} from Github API`)
   const client = new github.GitHub(token)
   const pageSize = 100
   const files: File[] = []
   let response: Octokit.Response<Octokit.PullsListFilesResponse>
   let page = 0
   do {
+    core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, page: ${page}, per_page: ${pageSize})`)
     response = await client.pulls.listFiles({
       owner: github.context.repo.owner,
       repo: github.context.repo.repo,
@@ -139,6 +140,7 @@ async function getChangedFilesFromApi(
       per_page: pageSize
     })
     for (const row of response.data) {
+      core.info(`[${row.status}] ${row.filename}`)
       // There's no obvious use-case for detection of renames
       // Therefore we treat it as if rename detection in git diff was turned off.
       // Rename is replaced by delete of original filename and add of new filename
@@ -162,6 +164,7 @@ async function getChangedFilesFromApi(
     page++
   } while (response?.data?.length > 0)
 
+  core.endGroup()
   return files
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,7 @@ async function getChangedFilesFromApi(
   const client = new github.GitHub(token)
   const pageSize = 100
   const files: File[] = []
-  for (let page = 1; page * pageSize < pullRequest.changed_files; page++) {
+  for (let page = 1; (page - 1) * pageSize < pullRequest.changed_files; page++) {
     core.info(`Invoking listFiles(pull_number: ${pullRequest.number}, page: ${page}, per_page: ${pageSize})`)
     const response = await client.pulls.listFiles({
       owner: github.context.repo.owner,

--- a/src/main.ts
+++ b/src/main.ts
@@ -153,9 +153,11 @@ async function getChangedFilesFromApi(
           status: ChangeStatus.Deleted
         })
       } else {
+        // Github status and git status variants are same except for deleted files
+        const status = row.status === 'removed' ? ChangeStatus.Deleted : (row.status as ChangeStatus)
         files.push({
           filename: row.filename,
-          status: row.status as ChangeStatus
+          status
         })
       }
     }


### PR DESCRIPTION
Follow-up for #50 

Previous PR fixed issued with retrieval of changes when there were 100+ changed files by rewriting `for` loop to `while` loop until API returns more data.

Later was discovered that this caused different bug - changed files were processed twice and as a result listed twice in `*_files` output. Turns out that root cause was in wrongly implemented pagination - pages starts at `1` instead of `0`.

Another bug was later discovered - Github returns for deleted files status 'removed' while we were using enum variant 'deleted'.
This is also fixed in this PR