### PR TITLE
Support local changes

### DIFF
--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -71,6 +71,23 @@ jobs:
       if: steps.filter.outputs.any != 'true' || steps.filter.outputs.error == 'true'
       run: exit 1
 
+  test-local-changes:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: echo "NEW FILE" > local
+    - run: git add local
+    - uses: ./
+      id: filter
+      with:
+        base: HEAD
+        filters: |
+          local:
+            - local
+    - name: filter-test
+      if: steps.filter.outputs.local != 'true'
+      run: exit 1
+
   test-change-type:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.6.0
+- [Support local changes](https://github.com/dorny/paths-filter/pull/53)
+
 ## v2.5.3
 - [Fixed mapping of removed/deleted change status from github API](https://github.com/dorny/paths-filter/pull/51)
 - [Fixed retrieval of all changes via Github API when there are 100+ changes](https://github.com/dorny/paths-filter/pull/50)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ For more scenarios see [examples](#examples) section.
 
 
 # What's New
+- Support local changes
 - Fixed retrieval of all changes via Github API when there are 100+ changes
 - Paths expressions are now evaluated using [picomatch](https://github.com/micromatch/picomatch) library
 - Support workflows triggered by any event

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ doesn't allow this because they doesn't work on a level of individual jobs or st
   when `base` input parameter is same as the branch that triggered the workflow:
     - Changes are detected from last commit
   - Uses git commands to detect changes - repository must be already [checked out](https://github.com/actions/checkout)
+- **Local changes**
+  - Workflow triggered by any event when `base` input parameter is set to `HEAD`
+  - Changes are detected against current HEAD
+  - Untracked files are ignored
 
 ## Example
 ```yaml
@@ -300,6 +304,35 @@ jobs:
         # you can specify it directly.
         # If it's not configured, the repository default branch is used.
         base: ${{ github.ref }}
+        filters: ... # Configure your filters
+```
+</details>
+
+<details>
+  <summary><b>Local changes:</b> Detect staged and unstaged local changes</summary>
+
+```yaml
+on:
+  push:
+    branches: # Push to following branches will trigger the workflow
+      - master
+      - develop
+      - release/**
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+      # Some action which modifies files tracked by git (e.g. code linter)
+    - uses: johndoe/some-action@v1
+
+      # Filter to detect which files were modified
+      # Changes could be for example automatically committed
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        base: HEAD
         filters: ... # Configure your filters
 ```
 </details>

--- a/src/git.ts
+++ b/src/git.ts
@@ -3,6 +3,7 @@ import * as core from '@actions/core'
 import {File, ChangeStatus} from './file'
 
 export const NULL_SHA = '0000000000000000000000000000000000000000'
+export const HEAD = 'HEAD'
 
 export async function getChangesInLastCommit(): Promise<File[]> {
   core.startGroup(`Change detection in last commit`)
@@ -31,6 +32,20 @@ export async function getChanges(ref: string): Promise<File[]> {
   try {
     // Two dots '..' change detection - directly compares two versions
     output = (await exec('git', ['diff', '--no-renames', '--name-status', '-z', `${ref}..HEAD`])).stdout
+  } finally {
+    fixStdOutNullTermination()
+    core.endGroup()
+  }
+
+  return parseGitDiffOutput(output)
+}
+
+export async function getChangesOnHead(): Promise<File[]> {
+  // Get current changes - both staged and unstaged
+  core.startGroup(`Change detection on HEAD`)
+  let output = ''
+  try {
+    output = (await exec('git', ['diff', '--no-renames', '--name-status', '-z', 'HEAD'])).stdout
   } finally {
     fixStdOutNullTermination()
     core.endGroup()


### PR DESCRIPTION
This PR adds support for local changes - i.e. it compares current state against HEAD.
Changed files could be staged or unstaged. New files must be added (`git add`) first so they are tracked by git.
Local change detection is used when `base`  input parameter is set to `HEAD`

Detection of local changes could be useful when used together with some action which modifies source files - e.g. linter which can automatically fix found issues.

closes #52 