### PR TITLE
Add "changes" output variable to support matrix job configuration

### DIFF
--- a/.github/workflows/pull-request-verification.yml
+++ b/.github/workflows/pull-request-verification.yml
@@ -29,6 +29,9 @@ jobs:
     - name: filter-test
       if: steps.filter.outputs.any != 'true' || steps.filter.outputs.error == 'true'
       run: exit 1
+    - name: changes-test
+      if: contains(fromJSON(steps.filter.outputs.changes), 'error') || !contains(fromJSON(steps.filter.outputs.changes), 'any')
+      run: exit 1
 
   test-external:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
       This option takes effect only when changes are detected using git against different base branch.
     required: false
     default: '10'
+outputs:
+  changes:
+    description: JSON array with names of all filters matching any of changed files
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -4791,10 +4791,12 @@ async function getChangedFilesFromApi(token, pullRequest) {
 }
 function exportResults(results, format) {
     core.info('Results:');
+    const changes = [];
     for (const [key, files] of Object.entries(results)) {
         const value = files.length > 0;
         core.startGroup(`Filter ${key} = ${value}`);
         if (files.length > 0) {
+            changes.push(key);
             core.info('Matching files:');
             for (const file of files) {
                 core.info(`${file.filename} [${file.status}]`);
@@ -4808,6 +4810,14 @@ function exportResults(results, format) {
             const filesValue = serializeExport(files, format);
             core.setOutput(`${key}_files`, filesValue);
         }
+    }
+    if (results['changes'] === undefined) {
+        const changesJson = JSON.stringify(changes);
+        core.info(`Changes output set to ${changesJson}`);
+        core.setOutput('changes', changesJson);
+    }
+    else {
+        core.info('Cannot set changes output variable - name already used by filter output');
     }
     core.endGroup();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -175,10 +175,12 @@ async function getChangedFilesFromApi(
 
 function exportResults(results: FilterResults, format: ExportFormat): void {
   core.info('Results:')
+  const changes = []
   for (const [key, files] of Object.entries(results)) {
     const value = files.length > 0
     core.startGroup(`Filter ${key} = ${value}`)
     if (files.length > 0) {
+      changes.push(key)
       core.info('Matching files:')
       for (const file of files) {
         core.info(`${file.filename} [${file.status}]`)
@@ -192,6 +194,14 @@ function exportResults(results: FilterResults, format: ExportFormat): void {
       const filesValue = serializeExport(files, format)
       core.setOutput(`${key}_files`, filesValue)
     }
+  }
+
+  if (results['changes'] === undefined) {
+    const changesJson = JSON.stringify(changes)
+    core.info(`Changes output set to ${changesJson}`)
+    core.setOutput('changes', changesJson)
+  } else {
+    core.info('Cannot set changes output variable - name already used by filter output')
   }
   core.endGroup()
 }


### PR DESCRIPTION
This PR significantly simplifies using this action to configure matrix job variable.
Previously the only option was to use `jq` to get matched filters from action output and transform it into JSON array.
Now the `changes` output variable is set to JSON array with names of all filters matching any of changed files.
This can be directly used to configure matrix job.

closes #55 