### PR TITLE
Fetch base and search merge-base without creating local branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.9.2
+- [Fix fetching git history](https://github.com/dorny/paths-filter/pull/75)
+
 ## v2.9.1
 - [Fix fetching git history + fallback to unshallow repo](https://github.com/dorny/paths-filter/pull/74)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3873,29 +3873,25 @@ async function getChangesSinceMergeBase(base, initialFetchDepth) {
     let noMergeBase = false;
     core.startGroup(`Searching for merge-base ${baseRef}...${exports.HEAD}`);
     try {
-        let init = true;
-        let lastCommitCount = await getCommitCount();
-        let depth = Math.max(lastCommitCount * 2, initialFetchDepth);
-        while (!(await hasMergeBase())) {
-            if (init) {
-                await exec_1.default('git', ['fetch', `--depth=${depth}`, 'origin', base, exports.HEAD]);
-                init = false;
-            }
-            else {
+        if (!(await hasMergeBase())) {
+            await exec_1.default('git', ['fetch', `--depth=${initialFetchDepth}`, 'origin', base, exports.HEAD]);
+            let depth = initialFetchDepth;
+            let lastCommitCount = await getCommitCount();
+            while (!(await hasMergeBase())) {
+                depth = Math.min(depth * 2, Number.MAX_SAFE_INTEGER);
                 await exec_1.default('git', ['fetch', `--deepen=${depth}`, 'origin', base, exports.HEAD]);
-            }
-            const commitCount = await getCommitCount();
-            if (commitCount === lastCommitCount) {
-                core.info('No more commits were fetched');
-                core.info('Last attempt will be to fetch full history');
-                await exec_1.default('git', ['fetch']);
-                if (!(await hasMergeBase())) {
-                    noMergeBase = true;
+                const commitCount = await getCommitCount();
+                if (commitCount === lastCommitCount) {
+                    core.info('No more commits were fetched');
+                    core.info('Last attempt will be to fetch full history');
+                    await exec_1.default('git', ['fetch']);
+                    if (!(await hasMergeBase())) {
+                        noMergeBase = true;
+                    }
+                    break;
                 }
-                break;
+                lastCommitCount = commitCount;
             }
-            depth = Math.min(depth * 2, Number.MAX_SAFE_INTEGER);
-            lastCommitCount = commitCount;
         }
     }
     finally {

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,7 +109,7 @@ async function getChangedFilesFromGit(base: string, initialFetchDepth: number): 
     if (baseSha === git.NULL_SHA) {
       if (defaultRef && baseRef !== defaultRef) {
         core.info(`First push of a branch detected - changes will be detected against the default branch ${defaultRef}`)
-        return await git.getChangesSinceMergeBase(defaultRef, initialFetchDepth)
+        return await git.getChangesSinceMergeBase(defaultRef, ref, initialFetchDepth)
       } else {
         core.info('Initial push detected - all files will be listed as added')
         return await git.listAllFilesAsAdded()
@@ -122,7 +122,7 @@ async function getChangedFilesFromGit(base: string, initialFetchDepth: number): 
 
   // Changes introduced by current branch against the base branch
   core.info(`Changes will be detected against the branch ${baseRef}`)
-  return await git.getChangesSinceMergeBase(baseRef, initialFetchDepth)
+  return await git.getChangesSinceMergeBase(baseRef, ref, initialFetchDepth)
 }
 
 // Uses github REST api to get list of files changed in PR

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,7 +109,7 @@ async function getChangedFilesFromGit(base: string, initialFetchDepth: number): 
     if (baseSha === git.NULL_SHA) {
       if (defaultRef && baseRef !== defaultRef) {
         core.info(`First push of a branch detected - changes will be detected against the default branch ${defaultRef}`)
-        return await git.getChangesSinceMergeBase(defaultRef, ref, initialFetchDepth)
+        return await git.getChangesSinceMergeBase(defaultRef, initialFetchDepth)
       } else {
         core.info('Initial push detected - all files will be listed as added')
         return await git.listAllFilesAsAdded()
@@ -122,7 +122,7 @@ async function getChangedFilesFromGit(base: string, initialFetchDepth: number): 
 
   // Changes introduced by current branch against the base branch
   core.info(`Changes will be detected against the branch ${baseRef}`)
-  return await git.getChangesSinceMergeBase(baseRef, ref, initialFetchDepth)
+  return await git.getChangesSinceMergeBase(baseRef, initialFetchDepth)
 }
 
 // Uses github REST api to get list of files changed in PR


### PR DESCRIPTION
This PR fixes issue mentioned in  https://github.com/dorny/paths-filter/pull/74#issuecomment-794105800

Previous version didn't work if there was a full repository clone (e.g. actions/checkout@v2 with fetch-depth: 0)  but base branch was tracked only as remote.

Now it doesn't matter if base is tracked locally. All checks uses  `remotes/origin/${base}` instead.
In any case full fetching  with `git fetch` no longer uses `--unshallow` argument which caused failure if repository was not shallow.