### PR TITLE
Fix change detection when base is a tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.9.3
+- [Fix change detection when base is a tag](https://github.com/dorny/paths-filter/pull/78)
+
 ## v2.9.2
 - [Fix fetching git history](https://github.com/dorny/paths-filter/pull/75)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -3871,7 +3871,7 @@ async function getChangesSinceMergeBase(base, ref, initialFetchDepth) {
         return (baseRef !== undefined && (await exec_1.default('git', ['merge-base', baseRef, ref], { ignoreReturnCode: true })).code === 0);
     }
     let noMergeBase = false;
-    core.startGroup(`Searching for merge-base ${baseRef}...${ref}`);
+    core.startGroup(`Searching for merge-base ${base}...${ref}`);
     try {
         baseRef = await getFullRef(base);
         if (!(await hasMergeBase())) {
@@ -4776,7 +4776,7 @@ async function getChangedFilesFromGit(base, initialFetchDepth) {
         return await git.getChanges(baseSha);
     }
     // Changes introduced by current branch against the base branch
-    core.info(`Changes will be detected against the branch ${baseRef}`);
+    core.info(`Changes will be detected against ${baseRef}`);
     return await git.getChangesSinceMergeBase(baseRef, ref, initialFetchDepth);
 }
 // Uses github REST api to get list of files changed in PR

--- a/src/git.ts
+++ b/src/git.ts
@@ -57,7 +57,9 @@ export async function getChangesOnHead(): Promise<File[]> {
 export async function getChangesSinceMergeBase(base: string, ref: string, initialFetchDepth: number): Promise<File[]> {
   let baseRef: string | undefined
   async function hasMergeBase(): Promise<boolean> {
-    return baseRef !== undefined && (await exec('git', ['merge-base', baseRef, ref], {ignoreReturnCode: true})).code === 0
+    return (
+      baseRef !== undefined && (await exec('git', ['merge-base', baseRef, ref], {ignoreReturnCode: true})).code === 0
+    )
   }
 
   let noMergeBase = false
@@ -200,8 +202,8 @@ async function getCommitCount(): Promise<number> {
   return isNaN(count) ? 0 : count
 }
 
-async function getFullRef(shortName: string) {
-  if(isGitSha(shortName)) {
+async function getFullRef(shortName: string): Promise<string | undefined> {
+  if (isGitSha(shortName)) {
     return shortName
   }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -63,7 +63,7 @@ export async function getChangesSinceMergeBase(base: string, ref: string, initia
   }
 
   let noMergeBase = false
-  core.startGroup(`Searching for merge-base ${baseRef}...${ref}`)
+  core.startGroup(`Searching for merge-base ${base}...${ref}`)
   try {
     baseRef = await getFullRef(base)
     if (!(await hasMergeBase())) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,7 +121,7 @@ async function getChangedFilesFromGit(base: string, initialFetchDepth: number): 
   }
 
   // Changes introduced by current branch against the base branch
-  core.info(`Changes will be detected against the branch ${baseRef}`)
+  core.info(`Changes will be detected against ${baseRef}`)
   return await git.getChangesSinceMergeBase(baseRef, ref, initialFetchDepth)
 }
 


### PR DESCRIPTION
This PR fixes invalid assumption that base will always be a branch.
Instead it tries to determine full ref name using `git show-ref`.
If ref is still not available after first fetch, then it executes fetch again with `--tags` option.

It also changes behavior when no merge base is found .
Instead of returning all files as changed it performs direct comparison between two commits.

closes #77 