### PR TITLE
Refactor exec() wrapper to handle Unicode

### DIFF
--- a/src/exec.ts
+++ b/src/exec.ts
@@ -4,14 +4,14 @@ import {exec as execImpl, ExecOptions} from '@actions/exec'
 // Returns exit code and whole stdout/stderr
 export default async function exec(commandLine: string, args?: string[], options?: ExecOptions): Promise<ExecResult> {
   options = options || {}
-  let stdout = ''
-  let stderr = ''
+  let stdout = []
+  let stderr = []
   options.listeners = {
-    stdout: (data: Buffer) => (stdout += data.toString()),
-    stderr: (data: Buffer) => (stderr += data.toString())
+    stdout: (data: Buffer) => stdout.push(data),
+    stderr: (data: Buffer) => stderr.push(data),
   }
   const code = await execImpl(commandLine, args, options)
-  return {code, stdout, stderr}
+  return {code, Buffer.concat(stdout).toString(), Buffer.concat(stderr).toString()}
 }
 
 export interface ExecResult {


### PR DESCRIPTION
Hopefully fixes #140 
I'm assuming that `execImpl` doesn't reuse the buffers they pass to the listeners.
If it does, a different solution is needed.

OTOH, maybe the action can use `getExecOutput` from https://github.com/actions/toolkit/blob/main/packages/exec/src/exec.ts directly?