### PR TITLE
Set `list-files` input parameter as not required

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ inputs:
                   If needed it uses single or double quotes to wrap filename with unsafe characters.
         'escape'- Space delimited list usable as command line argument list in linux shell.
                   Backslash escapes every potentially unsafe character.
-    required: true
+    required: false
     default: none
   initial-fetch-depth:
     description: |


### PR DESCRIPTION

There is a default value provided in the action metadata file so the input parameter should be specified as not required. Leaving it marked as required causes workflow validation errors when leaving out this parameter.