### PR TITLE
Update Node.js

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ outputs:
   changes:
     description: JSON array with names of all filters matching any of changed files
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   color: blue


### PR DESCRIPTION
`dorny/paths-filter` uses Node.js 12.
However, it is already EOL.
Therefore, I update it to 16 (Active LTS).

For your information: https://github.com/nodejs/Release