### PR TITLE
Update Node.js to version 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ outputs:
   changes:
     description: JSON array with names of all filters matching any of changed files
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   color: blue


### PR DESCRIPTION
Fix deprecation warning. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.