### PR TITLE
Update to nodejs 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ outputs:
   changes:
     description: JSON array with names of all filters matching any of changed files
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   color: blue

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/picomatch": "^2.2.1",
         "@typescript-eslint/eslint-plugin": "^5.10.2",
         "@typescript-eslint/parser": "^5.10.2",
-        "@vercel/ncc": "^0.33.1",
+        "@vercel/ncc": "^0.38.1",
         "eslint": "^8.17.0",
         "eslint-plugin-github": "^4.3.6",
         "eslint-plugin-jest": "^22.21.0",
@@ -1994,9 +1994,9 @@
       }
     },
     "node_modules/@vercel/ncc": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.1.tgz",
-      "integrity": "sha512-Mlsps/P0PLZwsCFtSol23FGqT3FhBGb4B1AuGQ52JTAtXhak+b0Fh/4T55r0/SVQPeRiX9pNItOEHwakGPmZYA==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
@@ -9991,9 +9991,9 @@
       }
     },
     "@vercel/ncc": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.33.1.tgz",
-      "integrity": "sha512-Mlsps/P0PLZwsCFtSol23FGqT3FhBGb4B1AuGQ52JTAtXhak+b0Fh/4T55r0/SVQPeRiX9pNItOEHwakGPmZYA==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.1.tgz",
+      "integrity": "sha512-IBBb+iI2NLu4VQn3Vwldyi2QwaXt5+hTyh58ggAMoCGE6DJmPvwL3KPBWcJl1m9LYPChBLE980Jw+CS4Wokqxw==",
       "dev": true
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/picomatch": "^2.2.1",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
-    "@vercel/ncc": "^0.33.1",
+    "@vercel/ncc": "^0.38.1",
     "eslint": "^8.17.0",
     "eslint-plugin-github": "^4.3.6",
     "eslint-plugin-jest": "^22.21.0",


### PR DESCRIPTION
Updates Node.js version to v20 as the previous version is out of support.
Applies again changes from #206 and also updates ncc version, which fixes the build error.