### PR TITLE
Add missing `predicate-quantifier` input definition to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,13 @@ inputs:
       This option takes effect only when changes are detected using git against different base branch.
     required: false
     default: '100'
+  predicate-quantifier:
+    description: |
+      Optional parameter to override the default behavior of file matching algorithm.
+      By default files that match at least one pattern defined by the filters will be included.
+      This parameter allows to override the "at least one pattern" behavior to make it so that
+      all of the patterns have to match or otherwise the file is excluded.
+    required: false
 outputs:
   changes:
     description: JSON array with names of all filters matching any of changed files


### PR DESCRIPTION
The `predicate-quantifier` input was added at v3.0.2 but is not listed in action.yml.

Though listing inputs is optional, [actionlint](https://github.com/rhysd/actionlint) looks at them to verify the usage of the inputs.

This PR adds the missing input definition to the manifest file so that it can solve the issue: https://github.com/rhysd/actionlint/issues/416