### PR TITLE
Add missing description for predicate-quantifier

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,16 @@ inputs:
   filters:
     description: 'Path to the configuration file or YAML string with filters definition'
     required: true
+  predicate-quantifier:
+    description: |
+      Optional parameter to override the default behavior of file matching algorithm. 
+      By default files that match at least one pattern defined by the filters will be included.
+      This parameter allows to override the "at least one pattern" behavior to make it so that
+      all of the patterns have to match or otherwise the file is excluded:
+        'some'  - Default behavior if any of the provided patterns match it is considered a match
+        'every' - All provided patters have to match to be considered a match
+    required: false
+    default: some
   list-files:
     description: |
       Enables listing of files matching the filter:


### PR DESCRIPTION
https://github.com/dorny/paths-filter/pull/224 introduced the parameter `predicate-quantifier` that can be used to adapt the behavior of multiple patters and if the all need to match or only some for the filter to apply.

This adds a description for the new parameter to `action.yml`.