### PR TITLE
Allow changed files as input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,13 @@
-name: 'Paths Changes Filter'
-description: 'Execute your workflow steps only if relevant files are modified.'
-author: 'Michal Dorner <dorner.michal@gmail.com>'
+name: "Paths Changes Filter"
+description: "Execute your workflow steps only if relevant files are modified."
+author: "Michal Dorner <dorner.michal@gmail.com>"
 inputs:
   token:
-    description: 'GitHub Access Token'
+    description: "GitHub Access Token"
     required: false
     default: ${{ github.token }}
   working-directory:
-    description: 'Relative path under $GITHUB_WORKSPACE where the repository was checked out.'
+    description: "Relative path under $GITHUB_WORKSPACE where the repository was checked out."
     required: false
   ref:
     description: |
@@ -20,8 +20,11 @@ inputs:
       If it references same branch it was pushed to, changes are detected against the most recent commit before the push.
       This option is ignored if action is triggered by pull_request event.
     required: false
+  files:
+    description: "Manual list of files to filter"
+    required: false
   filters:
-    description: 'Path to the configuration file or YAML string with filters definition'
+    description: "Path to the configuration file or YAML string with filters definition"
     required: true
   list-files:
     description: |
@@ -43,13 +46,13 @@ inputs:
       until the merge-base is found or there are no more commits in the history.
       This option takes effect only when changes are detected using git against different base branch.
     required: false
-    default: '100'
+    default: "100"
 outputs:
   changes:
     description: JSON array with names of all filters matching any of changed files
 runs:
-  using: 'node20'
-  main: 'dist/index.js'
+  using: "node20"
+  main: "dist/index.js"
 branding:
   color: blue
   icon: filter

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,7 @@ async function run(): Promise<void> {
     const filterConfig: FilterConfig = { predicateQuantifier }
 
     const filter = new Filter(filtersYaml, filterConfig)
+    core.info(`Detected ${filesInput} files`)
     const files = await getChangedFiles(filesInput, token, base, ref, initialFetchDepth)
     core.info(`Detected ${files.length} changed files`)
     const results = filter.match(files)

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,8 @@ import * as core from '@actions/core'
 import * as fs from 'fs'
 import * as github from '@actions/github'
 import * as jsyaml from 'js-yaml'
-import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types'
-import { PushEvent, PullRequestEvent } from '@octokit/webhooks-types'
+import {GetResponseDataTypeFromEndpointMethod} from '@octokit/types'
+import {PushEvent, PullRequestEvent} from '@octokit/webhooks-types'
 
 import {
   isPredicateQuantifier,
@@ -13,29 +13,29 @@ import {
   PredicateQuantifier,
   SUPPORTED_PREDICATE_QUANTIFIERS
 } from './filter'
-import { File, ChangeStatus } from './file'
+import {File, ChangeStatus} from './file'
 import * as git from './git'
-import { backslashEscape, shellEscape } from './list-format/shell-escape'
-import { csvEscape } from './list-format/csv-escape'
+import {backslashEscape, shellEscape} from './list-format/shell-escape'
+import {csvEscape} from './list-format/csv-escape'
 
 type ExportFormat = 'none' | 'csv' | 'json' | 'shell' | 'escape'
 
 async function run(): Promise<void> {
   try {
-    const workingDirectory = core.getInput('working-directory', { required: false })
+    const workingDirectory = core.getInput('working-directory', {required: false})
     if (workingDirectory) {
       process.chdir(workingDirectory)
     }
 
-    const token = core.getInput('token', { required: false })
-    const ref = core.getInput('ref', { required: false })
-    const base = core.getInput('base', { required: false })
-    const filesInput = core.getInput('files', { required: false })
-    const filtersInput = core.getInput('filters', { required: true })
+    const token = core.getInput('token', {required: false})
+    const ref = core.getInput('ref', {required: false})
+    const base = core.getInput('base', {required: false})
+    const filesInput = core.getInput('files', {required: false})
+    const filtersInput = core.getInput('filters', {required: true})
     const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput
-    const listFiles = core.getInput('list-files', { required: false }).toLowerCase() || 'none'
-    const initialFetchDepth = parseInt(core.getInput('initial-fetch-depth', { required: false })) || 10
-    const predicateQuantifier = core.getInput('predicate-quantifier', { required: false }) || PredicateQuantifier.SOME
+    const listFiles = core.getInput('list-files', {required: false}).toLowerCase() || 'none'
+    const initialFetchDepth = parseInt(core.getInput('initial-fetch-depth', {required: false})) || 10
+    const predicateQuantifier = core.getInput('predicate-quantifier', {required: false}) || PredicateQuantifier.SOME
 
     if (!isExportFormat(listFiles)) {
       core.setFailed(`Input parameter 'list-files' is set to invalid value '${listFiles}'`)
@@ -48,7 +48,7 @@ async function run(): Promise<void> {
         `'${predicateQuantifier}'. Valid values: ${SUPPORTED_PREDICATE_QUANTIFIERS.join(', ')}`
       throw new Error(predicateQuantifierInvalidErrorMsg)
     }
-    const filterConfig: FilterConfig = { predicateQuantifier }
+    const filterConfig: FilterConfig = {predicateQuantifier}
 
     const filter = new Filter(filtersYaml, filterConfig)
     core.info(`Detected ${filesInput} files`)
@@ -74,7 +74,7 @@ function getConfigFileContent(configPath: string): string {
     throw new Error(`'${configPath}' is not a file.`)
   }
 
-  return fs.readFileSync(configPath, { encoding: 'utf8' })
+  return fs.readFileSync(configPath, {encoding: 'utf8'})
 }
 
 async function getChangedFiles(
@@ -87,7 +87,7 @@ async function getChangedFiles(
   if (files) {
     core.info('Using list of files provided as input')
     const doc = jsyaml.load(files) as string[]
-    return doc.map(filename => ({ filename, status: ChangeStatus.Modified }))
+    return doc.map(filename => ({filename, status: ChangeStatus.Modified}))
   }
 
   // if base is 'HEAD' only local uncommitted changes will be detected

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,6 +84,7 @@ async function getChangedFiles(
   initialFetchDepth: number
 ): Promise<File[]> {
   if (files) {
+    core.info('Using list of files provided as input')
     const doc = jsyaml.load(files) as string[]
     return doc.map(filename => ({ filename, status: ChangeStatus.Modified }))
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
-import * as fs from 'fs'
 import * as core from '@actions/core'
+import * as fs from 'fs'
 import * as github from '@actions/github'
-import {GetResponseDataTypeFromEndpointMethod} from '@octokit/types'
-import {PushEvent, PullRequestEvent} from '@octokit/webhooks-types'
+import * as jsyaml from 'js-yaml'
+import { GetResponseDataTypeFromEndpointMethod } from '@octokit/types'
+import { PushEvent, PullRequestEvent } from '@octokit/webhooks-types'
 
 import {
   isPredicateQuantifier,
@@ -12,28 +13,29 @@ import {
   PredicateQuantifier,
   SUPPORTED_PREDICATE_QUANTIFIERS
 } from './filter'
-import {File, ChangeStatus} from './file'
+import { File, ChangeStatus } from './file'
 import * as git from './git'
-import {backslashEscape, shellEscape} from './list-format/shell-escape'
-import {csvEscape} from './list-format/csv-escape'
+import { backslashEscape, shellEscape } from './list-format/shell-escape'
+import { csvEscape } from './list-format/csv-escape'
 
 type ExportFormat = 'none' | 'csv' | 'json' | 'shell' | 'escape'
 
 async function run(): Promise<void> {
   try {
-    const workingDirectory = core.getInput('working-directory', {required: false})
+    const workingDirectory = core.getInput('working-directory', { required: false })
     if (workingDirectory) {
       process.chdir(workingDirectory)
     }
 
-    const token = core.getInput('token', {required: false})
-    const ref = core.getInput('ref', {required: false})
-    const base = core.getInput('base', {required: false})
-    const filtersInput = core.getInput('filters', {required: true})
+    const token = core.getInput('token', { required: false })
+    const ref = core.getInput('ref', { required: false })
+    const base = core.getInput('base', { required: false })
+    const filesInput = core.getInput('files', { required: false })
+    const filtersInput = core.getInput('filters', { required: true })
     const filtersYaml = isPathInput(filtersInput) ? getConfigFileContent(filtersInput) : filtersInput
-    const listFiles = core.getInput('list-files', {required: false}).toLowerCase() || 'none'
-    const initialFetchDepth = parseInt(core.getInput('initial-fetch-depth', {required: false})) || 10
-    const predicateQuantifier = core.getInput('predicate-quantifier', {required: false}) || PredicateQuantifier.SOME
+    const listFiles = core.getInput('list-files', { required: false }).toLowerCase() || 'none'
+    const initialFetchDepth = parseInt(core.getInput('initial-fetch-depth', { required: false })) || 10
+    const predicateQuantifier = core.getInput('predicate-quantifier', { required: false }) || PredicateQuantifier.SOME
 
     if (!isExportFormat(listFiles)) {
       core.setFailed(`Input parameter 'list-files' is set to invalid value '${listFiles}'`)
@@ -46,10 +48,10 @@ async function run(): Promise<void> {
         `'${predicateQuantifier}'. Valid values: ${SUPPORTED_PREDICATE_QUANTIFIERS.join(', ')}`
       throw new Error(predicateQuantifierInvalidErrorMsg)
     }
-    const filterConfig: FilterConfig = {predicateQuantifier}
+    const filterConfig: FilterConfig = { predicateQuantifier }
 
     const filter = new Filter(filtersYaml, filterConfig)
-    const files = await getChangedFiles(token, base, ref, initialFetchDepth)
+    const files = await getChangedFiles(filesInput, token, base, ref, initialFetchDepth)
     core.info(`Detected ${files.length} changed files`)
     const results = filter.match(files)
     exportResults(results, listFiles)
@@ -71,10 +73,21 @@ function getConfigFileContent(configPath: string): string {
     throw new Error(`'${configPath}' is not a file.`)
   }
 
-  return fs.readFileSync(configPath, {encoding: 'utf8'})
+  return fs.readFileSync(configPath, { encoding: 'utf8' })
 }
 
-async function getChangedFiles(token: string, base: string, ref: string, initialFetchDepth: number): Promise<File[]> {
+async function getChangedFiles(
+  files: string,
+  token: string,
+  base: string,
+  ref: string,
+  initialFetchDepth: number
+): Promise<File[]> {
+  if (files) {
+    const doc = jsyaml.load(files) as string[]
+    return doc.map(filename => ({ filename, status: ChangeStatus.Modified }))
+  }
+
   // if base is 'HEAD' only local uncommitted changes will be detected
   // This is the simplest case as we don't need to fetch more commits or evaluate current/before refs
   if (base === git.HEAD) {


### PR DESCRIPTION
We have a use-case in which we want to enrich the changed files/paths with some script and then run it through the filter. Since this action already does 90% of the job, I think it would be a great addition to support an additional optional input here that passes the list, instead of creating a new action.

Let me know what you think, and what would be required in order to merge this.

Thanks!

Example use-case:
```
      - uses: dorny/paths-filter@v3
        id: filter
        with:
          list-files: shell
          filters: |
            go:
              - go.mod
              - go.sum
              - "**.go"

      - id: go-find-cmd
        if: steps.filter.outputs.go == 'true'
        run: |
          echo "cmds<<EOF" >> "$GITHUB_OUTPUT"
          echo "$(./hack/go-find-cmd ${{ steps.filter.outputs.go_files }})" >> "$GITHUB_OUTPUT"
          echo "EOF" >> "$GITHUB_OUTPUT"

      - uses: pecigonzalo/paths-filter@feature/input-files
        if: steps.filter.outputs.go == 'true'
        id: go-filter
        with:
          files: ${{ steps.go-find-cmd.outputs.cmds }}
          filters: |
            foo:
              - cmd/foo/**
            bar:
              - cmd/bar/**
```

`./hack/go-find-cmd` provides yaml output like:
```
- foo
- bar
```