### PR TITLE
fix: warning for "unexpected input predicate-quantifier"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,13 @@ inputs:
       This option takes effect only when changes are detected using git against different base branch.
     required: false
     default: '100'
+  predicate-quantifier:
+    description: |
+      Overrides the default behavior of the file matching algorithm:
+        'every' - Matches files only if all file path patterns matched
+        'some'  - Matches files when one or more file path patterns match
+    required: false
+    default: some
 outputs:
   changes:
     description: JSON array with names of all filters matching any of changed files


### PR DESCRIPTION
# Overview

This PR addresses the GitHub warning:
```
Unexpected input(s) 'predicate-quantifier', valid inputs are ['token', 'working-directory', 'ref', 'base', 'filters', 'list-files', 'initial-fetch-depth']
```

Which appears in any GitHub action run using `dorny/paths-filter@v3` with `predicate-quantifier` configured.
 
# Description
At first, I thought my team's use of `dorny/paths-filter` was configured wrong.  I thought I needed to remove our use of `predicate-quantifier` but then saw [this GitHub issue](https://github.com/dorny/paths-filter/issues/225).  That linked to the [original PR](https://github.com/dorny/paths-filter/pull/224) where this was added.

I am not familiar with GitHub action development, but upon browsing `action.yaml`, I see all of the other possible inputs defined.  That did not have `predicate-quantifier`, so I believe this fix is as simple as defining it there.  This PR adds that, with a description based on the comments added by the original author.

# Testing
I am unsure of how to test this change.  Please advise and/or help with that aspect.