### PR TITLE
feat: add write-to-files feature to deal with large change sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ For more information, see [CHANGELOG](https://github.com/dorny/paths-filter/blob
     # Default: none
     list-files: ''
 
+    # Enables writing the lists of matching files to a corresponding file.
+    # If set, the action will create the specified file with the list of matching files.
+    # The file will be written in the format specified by the `list-files` option and named
+    # after the filter. The path to the file will be relative to the working directory and
+    # exported as an output variable named `<filter-name>_files_path`.
+    write-to-files: ''
+
     # Relative path under $GITHUB_WORKSPACE where the repository was checked out.
     working-directory: ''
 
@@ -154,14 +161,14 @@ For more information, see [CHANGELOG](https://github.com/dorny/paths-filter/blob
     # Default: ${{ github.token }}
     token: ''
 
-    # Optional parameter to override the default behavior of file matching algorithm. 
+    # Optional parameter to override the default behavior of file matching algorithm.
     # By default files that match at least one pattern defined by the filters will be included.
     # This parameter allows to override the "at least one pattern" behavior to make it so that
-    # all of the patterns have to match or otherwise the file is excluded. 
-    # An example scenario where this is useful if you would like to match all 
-    # .ts files in a sub-directory but not .md files. 
-    # The filters below will match markdown files despite the exclusion syntax UNLESS 
-    # you specify 'every' as the predicate-quantifier parameter. When you do that, 
+    # all of the patterns have to match or otherwise the file is excluded.
+    # An example scenario where this is useful if you would like to match all
+    # .ts files in a sub-directory but not .md files.
+    # The filters below will match markdown files despite the exclusion syntax UNLESS
+    # you specify 'every' as the predicate-quantifier parameter. When you do that,
     # it will only match the .ts files in the subdirectory as expected.
     #
     # backend:
@@ -501,6 +508,37 @@ jobs:
             - 'pkg/a/b/c/**'
             - '!**/*.jpeg'
             - '!**/*.md'
+```
+
+</details>
+
+<details>
+  <summary>Handle large change sets (2000+ files)</summary>
+
+```yaml
+- uses: dorny/paths-filter@v3
+  id: changed
+  with:
+    # Enable writing the files matching each filter to the disk in addition to the output '<filter_name>_files'.
+    # The path for each filter's file is output in the format '<filter_name>_files_path'.
+    write-to-files: true
+    list-files: json
+    filters: |
+      content:
+        - 'content/**'
+
+
+- name: List changed directories relative to the base directory
+  shell: bash
+  env:
+    BASE_DIR: ${{ inputs.base-directory }}
+    CHANGED_CONTENT_FILES_PATH: ${{ steps.changed.outputs.content_files_path }}
+  run: |
+    CHANGED_CONTENT_DIRECTORIES=$(cat "${CHANGED_CONTENT_FILES_PATH}" | xargs -n1 realpath -m --relative-to=${BASE_DIR} | cut -f1 -d / | sort -u)
+    for d in $CHANGED_CONTENT_DIRECTORIES
+    do
+      echo "Content directory change detected: ${d}"
+    done
 ```
 
 </details>

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,13 @@ inputs:
                   Backslash escapes every potentially unsafe character.
     required: false
     default: none
+  write-to-files:
+    description: |
+      Enables writing the lists of matching files to a corresponding file in addition to the output '<filter-name>_files'.
+      If set, the action will create the specified file with the list of matching files.
+      The file will be written in the format specified by the `list-files` option and named
+      after the filter. The path to the file will be output as a variable named `<filter-name>_files_path`.
+    required: false
   initial-fetch-depth:
     description: |
       How many commits are initially fetched from base branch.


### PR DESCRIPTION
This commit introduces a new input named 'write-to-files'. It enables writing
the lists of matching files to a corresponding file in addition to the output
'<filter-name>_files'. If set, the action will create the specified file with
the list of matching files. The file will be written in the format specified by
the `list-files` option and named after the filter. The path to the file will be
output as a variable named `<filter-name>_files_path`.

**Example of the issue**

```yaml
    - name: List changed files
      uses: dorny/paths-filter@v3
      id: changed
      with:
        filters: .github/path_filters.yaml
        list-files: escape
        write-to-files: true
        token: '' # Forces the use of the git binary (necessary for 3000+ files change sets)


    - name: Update the changed content files in the destination with the Pull Request changes
      shell: bash
      env:
        SOURCE: ${{ inputs.source }}
        DESTINATION_PATH: ${{ inputs.mountpoint }}/${{ inputs.destination }}
        CHANGED_CONTENT_FILES: ${{ steps.changed.outputs.content_files }}
      run: |
        RELATIVE_PATHS_LIST=$(printf '%s\n' ${{ steps.changed.outputs.content_files }} | xargs realpath -m --relative-to="${SOURCE}")
        cd "${SOURCE}"
        while read -r BATCH
         do
          cp --parents ${BATCH} ${DESTINATION_PATH}
        done <<< $(printf '%s\n' "${RELATIVE_PATHS_LIST}" | xargs)
```

**GitHub Actions message**
> [!NOTE]
> The change set tested has more than 2600 files. I wasn't even able to paste it here as a comment.
```
Error: An error occurred trying to start process '/usr/bin/docker' with working directory '/home/runner/_work'.
Argument list too long
```