### PR TITLE
Add missing predicate-quantifier

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,11 @@ inputs:
       This option takes effect only when changes are detected using git against different base branch.
     required: false
     default: '100'
+  predicate-quantifier:
+    description: |
+      allows to override the "at least one pattern" behavior to make it so that all of the patterns have to match or otherwise the file is excluded.
+    required: false
+    default: 'some'
 outputs:
   changes:
     description: JSON array with names of all filters matching any of changed files


### PR DESCRIPTION
Adds the `predicate-quantifier` to gh action.

Fixes https://github.com/dorny/paths-filter/issues/225