### PR TITLE
Compare commit SHAs instead of ref names for isBaseSameAsHead check

### DIFF
--- a/__tests__/git-resolve.test.ts
+++ b/__tests__/git-resolve.test.ts
@@ -1,0 +1,95 @@
+import * as git from '../src/git'
+import * as exec from '@actions/exec'
+
+jest.mock('@actions/exec')
+const mockedGetExecOutput = jest.mocked(exec.getExecOutput)
+
+beforeEach(() => {
+  mockedGetExecOutput.mockReset()
+})
+
+describe('resolveRefToSha', () => {
+  test('resolves a branch name to its commit SHA', async () => {
+    mockedGetExecOutput.mockResolvedValue({
+      exitCode: 0,
+      stdout: '8b399ed1681b9efd6b1e048ca1c5cba47edf3855\n',
+      stderr: ''
+    })
+    const sha = await git.resolveRefToSha('master')
+    expect(sha).toBe('8b399ed1681b9efd6b1e048ca1c5cba47edf3855')
+    expect(mockedGetExecOutput).toHaveBeenCalledWith('git', ['rev-parse', 'master'])
+  })
+
+  test('resolves a tag to its commit SHA', async () => {
+    mockedGetExecOutput.mockResolvedValue({
+      exitCode: 0,
+      stdout: '8b399ed1681b9efd6b1e048ca1c5cba47edf3855\n',
+      stderr: ''
+    })
+    const sha = await git.resolveRefToSha('release-18')
+    expect(sha).toBe('8b399ed1681b9efd6b1e048ca1c5cba47edf3855')
+    expect(mockedGetExecOutput).toHaveBeenCalledWith('git', ['rev-parse', 'release-18'])
+  })
+
+  test('returns SHA as-is when given a full SHA', async () => {
+    const fullSha = '8b399ed1681b9efd6b1e048ca1c5cba47edf3855'
+    mockedGetExecOutput.mockResolvedValue({
+      exitCode: 0,
+      stdout: `${fullSha}\n`,
+      stderr: ''
+    })
+    const sha = await git.resolveRefToSha(fullSha)
+    expect(sha).toBe(fullSha)
+  })
+})
+
+describe('isBaseSameAsHead with SHA comparison', () => {
+  test('different ref names pointing to same commit are treated as same', async () => {
+    const sameSha = '8b399ed1681b9efd6b1e048ca1c5cba47edf3855'
+    mockedGetExecOutput.mockResolvedValue({
+      exitCode: 0,
+      stdout: `${sameSha}\n`,
+      stderr: ''
+    })
+
+    const base: string = 'master'
+    const head: string = 'release-18'
+    const baseSha = await git.resolveRefToSha(base)
+    const headSha = await git.resolveRefToSha(head)
+    const isBaseSameAsHead = base === head || baseSha === headSha
+
+    expect(base === head).toBe(false) // ref names differ
+    expect(isBaseSameAsHead).toBe(true) // but SHAs match
+  })
+
+  test('different ref names pointing to different commits are not same', async () => {
+    mockedGetExecOutput
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n',
+        stderr: ''
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        stdout: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n',
+        stderr: ''
+      })
+
+    const base: string = 'master'
+    const head: string = 'feature/xyz'
+    const baseSha = await git.resolveRefToSha(base)
+    const headSha = await git.resolveRefToSha(head)
+    const isBaseSameAsHead = base === head || baseSha === headSha
+
+    expect(isBaseSameAsHead).toBe(false)
+  })
+
+  test('same ref names are detected without SHA resolution', async () => {
+    const base: string = 'master'
+    const head: string = 'master'
+    const isBaseSameAsHead = base === head
+
+    expect(isBaseSameAsHead).toBe(true)
+    expect(mockedGetExecOutput).not.toHaveBeenCalled()
+  })
+})

--- a/dist/index.js
+++ b/dist/index.js
@@ -204,7 +204,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.isGitSha = exports.getShortName = exports.getCurrentRef = exports.listAllFilesAsAdded = exports.parseGitDiffOutput = exports.getChangesSinceMergeBase = exports.getChangesOnHead = exports.getChanges = exports.getChangesInLastCommit = exports.HEAD = exports.NULL_SHA = void 0;
+exports.resolveRefToSha = exports.isGitSha = exports.getShortName = exports.getCurrentRef = exports.listAllFilesAsAdded = exports.parseGitDiffOutput = exports.getChangesSinceMergeBase = exports.getChangesOnHead = exports.getChanges = exports.getChangesInLastCommit = exports.HEAD = exports.NULL_SHA = void 0;
 const exec_1 = __nccwpck_require__(1514);
 const core = __importStar(__nccwpck_require__(2186));
 const file_1 = __nccwpck_require__(4014);
@@ -394,6 +394,11 @@ function isGitSha(ref) {
     return /^[a-z0-9]{40}$/.test(ref);
 }
 exports.isGitSha = isGitSha;
+async function resolveRefToSha(ref) {
+    const output = (await (0, exec_1.getExecOutput)('git', ['rev-parse', ref])).stdout.trim();
+    return output;
+}
+exports.resolveRefToSha = resolveRefToSha;
 async function hasCommit(ref) {
     return (await (0, exec_1.getExecOutput)('git', ['cat-file', '-e', `${ref}^{commit}`], { ignoreReturnCode: true })).exitCode === 0;
 }
@@ -675,7 +680,9 @@ async function getChangedFilesFromGit(base, head, initialFetchDepth) {
         throw new Error("This action requires 'base' input to be configured or 'repository.default_branch' to be set in the event payload");
     }
     const isBaseSha = git.isGitSha(base);
-    const isBaseSameAsHead = base === head;
+    const baseSha = await git.resolveRefToSha(base);
+    const headSha = await git.resolveRefToSha(head);
+    const isBaseSameAsHead = base === head || baseSha === headSha;
     // If base is commit SHA we will do comparison against the referenced commit
     // Or if base references same branch it was pushed to, we will do comparison against the previously pushed commit
     if (isBaseSha || isBaseSameAsHead) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -198,6 +198,11 @@ export function isGitSha(ref: string): boolean {
   return /^[a-z0-9]{40}$/.test(ref)
 }
 
+export async function resolveRefToSha(ref: string): Promise<string> {
+  const output = (await getExecOutput('git', ['rev-parse', ref])).stdout.trim()
+  return output
+}
+
 async function hasCommit(ref: string): Promise<boolean> {
   return (await getExecOutput('git', ['cat-file', '-e', `${ref}^{commit}`], {ignoreReturnCode: true})).exitCode === 0
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -153,7 +153,9 @@ async function getChangedFilesFromGit(base: string, head: string, initialFetchDe
   }
 
   const isBaseSha = git.isGitSha(base)
-  const isBaseSameAsHead = base === head
+  const baseSha = await git.resolveRefToSha(base)
+  const headSha = await git.resolveRefToSha(head)
+  const isBaseSameAsHead = base === head || baseSha === headSha
 
   // If base is commit SHA we will do comparison against the referenced commit
   // Or if base references same branch it was pushed to, we will do comparison against the previously pushed commit


### PR DESCRIPTION
### Problem

When deploying from a release tag (e.g. `release-18`) via `workflow_dispatch`, `paths-filter` incorrectly determines that `base` and `head` are different because it compares ref names instead of commit SHAs.

Even though both `master` and `release-18` point to the **same commit**, the string comparison fails. This causes `paths-filter` to take the merge-base code path, which returns 0 changes (since the tag is already on master), and all filters evaluate to `false`.

### Fix

Resolve both refs to their commit SHAs before comparing. The original `base === head` fast path is preserved — the SHA resolution only kicks in when ref names differ.

### Reproduction

1. Create a tag `release-18` pointing to the same commit as `master`
2. Trigger a `workflow_dispatch` deployment using `release-18`
3. `paths-filter` with default `base` (master) compares `"master" !== "release-18"` → takes merge-base path → 0 changes detected
4. Same deployment from `master` works because `"master" === "master"` → takes last commit path → changes detected correctly
