### PR TITLE
fix: scope base-ignored warning to API path

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ For more information, see [CHANGELOG](https://github.com/dorny/paths-filter/blob
     # introduced by the current branch are considered.
     # All files are considered as added if there is no common ancestor with
     # base branch or no previous commit.
-    # This option is ignored if action is triggered by pull_request event.
+    # This option is ignored if action is triggered by pull_request event,
+    # unless 'token' is set to an empty string (see the 'token' input below).
     # Default: repository default branch (e.g. master)
     base: ''
 
@@ -164,7 +165,9 @@ For more information, see [CHANGELOG](https://github.com/dorny/paths-filter/blob
     # It's only used if action is triggered by a pull request event.
     # GitHub token from workflow context is used as default value.
     # If an empty string is provided, the action falls back to detect
-    # changes using git commands.
+    # changes using git commands. In that case, on pull request events
+    # the 'base' input overrides the pull request base - e.g. set
+    # base: ${{ github.event.before }} to detect changes since the last push.
     # Default: ${{ github.token }}
     token: ''
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -659,11 +659,11 @@ async function getChangedFiles(token, base, ref, initialFetchDepth) {
             if (ref) {
                 core.warning(`'ref' input parameter is ignored when action is triggered by pull request event`);
             }
-            if (base) {
-                core.warning(`'base' input parameter is ignored when action is triggered by pull request event`);
-            }
             const pr = github.context.payload.pull_request;
             if (token) {
+                if (base) {
+                    core.warning(`'base' input parameter is ignored when action is triggered by pull request event and 'token' is provided - set token: '' to detect changes using git diff against 'base'`);
+                }
                 return await getChangedFilesFromApi(token, pr);
             }
             if (github.context.eventName === 'pull_request_target') {
@@ -673,6 +673,9 @@ async function getChangedFiles(token, base, ref, initialFetchDepth) {
                 throw new Error(`'token' input parameter is required if action is triggered by 'pull_request_target' event`);
             }
             core.info('GitHub token is not available - changes will be detected using git diff');
+            if (base) {
+                core.info(`Using base '${base}' instead of the pull request base`);
+            }
             const baseSha = (_a = github.context.payload.pull_request) === null || _a === void 0 ? void 0 : _a.base.sha;
             const defaultBranch = (_b = github.context.payload.repository) === null || _b === void 0 ? void 0 : _b.default_branch;
             const currentRef = await git.getCurrentRef();

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,11 +97,13 @@ async function getChangedFiles(token: string, base: string, ref: string, initial
       if (ref) {
         core.warning(`'ref' input parameter is ignored when action is triggered by pull request event`)
       }
-      if (base) {
-        core.warning(`'base' input parameter is ignored when action is triggered by pull request event`)
-      }
       const pr = github.context.payload.pull_request as PullRequest
       if (token) {
+        if (base) {
+          core.warning(
+            `'base' input parameter is ignored when action is triggered by pull request event and 'token' is provided - set token: '' to detect changes using git diff against 'base'`
+          )
+        }
         return await getChangedFilesFromApi(token, pr)
       }
       if (github.context.eventName === 'pull_request_target') {
@@ -111,6 +113,9 @@ async function getChangedFiles(token: string, base: string, ref: string, initial
         throw new Error(`'token' input parameter is required if action is triggered by 'pull_request_target' event`)
       }
       core.info('GitHub token is not available - changes will be detected using git diff')
+      if (base) {
+        core.info(`Using base '${base}' instead of the pull request base`)
+      }
       const baseSha = github.context.payload.pull_request?.base.sha
       const defaultBranch = github.context.payload.repository?.default_branch
       const currentRef = await git.getCurrentRef()


### PR DESCRIPTION
On pull request events the action always warned that the `base` input is ignored, even when `token: ''` is set, the exact case where the git diff fallback actually uses `base`.

The warning will now be emitted only on the API path, where `base` really is ignored, and will suggest setting `token: ''` to detect changes using git diff against `base`. The git fallback path logs which base is used in place of the pull request base.