### PR TITLE
Call rev-list with the specific commits instead of --all

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -317,11 +317,11 @@ async function getChangesSinceMergeBase(base, head, initialFetchDepth) {
                 }
             }
             let depth = initialFetchDepth;
-            let lastCommitCount = await getCommitCount();
+            let lastCommitCount = await getCommitCount([baseRef, headRef]);
             while (!(await hasMergeBase())) {
                 depth = Math.min(depth * 2, Number.MAX_SAFE_INTEGER);
                 await gitExec(['fetch', `--deepen=${depth}`, 'origin', base, head]);
-                const commitCount = await getCommitCount();
+                const commitCount = await getCommitCount([baseRef, headRef]);
                 if (commitCount === lastCommitCount) {
                     core.info('No more commits were fetched');
                     core.info('Last attempt will be to fetch full history');
@@ -425,8 +425,8 @@ exports.isGitSha = isGitSha;
 async function hasCommit(ref) {
     return (await gitExec(['cat-file', '-e', `${ref}^{commit}`], { ignoreReturnCode: true })).exitCode === 0;
 }
-async function getCommitCount() {
-    const output = (await gitExec(['rev-list', '--count', '--all'])).stdout;
+async function getCommitCount(commits) {
+    const output = (await gitExec(['rev-list', ...commits, '--count'])).stdout;
     const count = parseInt(output);
     return isNaN(count) ? 0 : count;
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -125,11 +125,11 @@ export async function getChangesSinceMergeBase(base: string, head: string, initi
       }
 
       let depth = initialFetchDepth
-      let lastCommitCount = await getCommitCount()
+      let lastCommitCount = await getCommitCount([baseRef, headRef])
       while (!(await hasMergeBase())) {
         depth = Math.min(depth * 2, Number.MAX_SAFE_INTEGER)
         await gitExec(['fetch', `--deepen=${depth}`, 'origin', base, head])
-        const commitCount = await getCommitCount()
+        const commitCount = await getCommitCount([baseRef, headRef])
         if (commitCount === lastCommitCount) {
           core.info('No more commits were fetched')
           core.info('Last attempt will be to fetch full history')
@@ -236,8 +236,8 @@ async function hasCommit(ref: string): Promise<boolean> {
   return (await gitExec(['cat-file', '-e', `${ref}^{commit}`], {ignoreReturnCode: true})).exitCode === 0
 }
 
-async function getCommitCount(): Promise<number> {
-  const output = (await gitExec(['rev-list', '--count', '--all'])).stdout
+async function getCommitCount(commits: string[]): Promise<number> {
+  const output = (await gitExec(['rev-list', ...commits, '--count'])).stdout
   const count = parseInt(output)
   return isNaN(count) ? 0 : count
 }


### PR DESCRIPTION
Fix for #321 

I ran `npm run all` and the tests all pass, and ran a few of our internal workflows with this change and it's looking good!